### PR TITLE
feat: bring agent configs to parity with Claude

### DIFF
--- a/src/ai_shell/templates/agents/agents.md
+++ b/src/ai_shell/templates/agents/agents.md
@@ -4,32 +4,53 @@
 
 <!-- Describe your project here. This file is read automatically by Codex and opencode. -->
 
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No manual versioning**: NEVER manually edit version numbers. Semantic Release manages versions via conventional commits.
+- **No lock file edits**: NEVER manually edit lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock). They are auto-generated.
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+
+## Development Commands
+
+```bash
+uv sync --all-extras                         # Install dependencies
+uv run pytest                                # Run tests
+uv run pytest --cov=src --cov-fail-under=80  # Tests with coverage
+uv run ruff check src/                       # Lint
+uv run mypy src/                             # Type check
+uv run pre-commit run --all-files            # Run all pre-commit hooks
+```
+
+## Conventions
+
+- **Commits**: Conventional commits required. `fix:` = patch, `feat:` = minor, `feat!:` / `BREAKING CHANGE` = major.
+- **Branches**: `{type}/issue-N-description` where type is one of: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf.
+- **PRs**: Target the default development branch. Enable automerge.
+- **Pre-commit**: Run `uv run pre-commit run --all-files` explicitly before committing (no automatic git hooks -- they break across Windows/WSL). If checks fail, fix the issue and create a NEW commit (do not amend).
+- **Tests**: Write tests for all new functionality. Bug fixes require regression tests.
+
 ## Development Workflow
 
 1. **Pick an issue**: Find or get assigned an issue to work on
 2. **Create a branch**: `git checkout -b feat/issue-N-description`
 3. **Develop**: Write code with tests, following project conventions
-4. **Submit**: Run checks, commit with conventional messages, create PR
-5. **Monitor**: Watch CI pipeline, fix any failures
-6. **Merge**: PR auto-merges after checks pass
-
-## Conventions
-
-- **Commits**: Use conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`)
-- **Branches**: `{feat|fix|docs}/issue-N-description`
-- **PRs**: Target the default development branch, enable automerge
-- **Tests**: Write tests for all new functionality
+4. **Check**: Run `uv run pre-commit run --all-files` and `uv run pytest`
+5. **Submit**: Commit with conventional messages, create PR
+6. **Monitor**: Watch CI pipeline, fix any failures
 
 ## Key Commands
 
 ```bash
-# Development
+# Git
 git status                    # Check working tree
+git log --oneline -10         # Recent commits
+
+# GitHub CLI
 gh issue list --state open    # View open issues
 gh pr create                  # Create pull request
 gh pr merge --auto --squash   # Enable automerge
-
-# CI/CD
 gh run list                   # List workflow runs
 gh run view <id>              # View run details
 gh run watch <id>             # Watch run in real-time

--- a/src/ai_shell/templates/agents/skills/ai-monitor-pipeline/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-monitor-pipeline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-monitor-pipeline
 description: Monitor CI pipeline after push, diagnose failures, auto-fix and re-push. Use after submitting work or to check pipeline status.
-disable-model-invocation: true
 argument-hint: "[run-id or branch-name]"
 ---
 

--- a/src/ai_shell/templates/agents/skills/ai-promote/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-promote/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-promote
 description: Promote staging (dev) to production (main) by creating an automerge PR. Use when dev/staging is ready for release.
-disable-model-invocation: true
 ---
 
 Promote staging to production by creating an automerge PR from dev to main: $ARGUMENTS

--- a/src/ai_shell/templates/agents/skills/ai-repo-health/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-repo-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-repo-health
 description: Comprehensive repository health check with remote-first git hygiene, branch cleanup, and code quality analysis. Use for repo maintenance and cleanup.
-disable-model-invocation: true
 argument-hint: "[--remote-only] [--local-only] [--dry-run]"
 ---
 

--- a/src/ai_shell/templates/agents/skills/ai-submit-work/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-submit-work/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-submit-work
 description: Run all status checks locally, fix issues, commit, push, and create an automerge PR. Use when work is ready to submit.
-disable-model-invocation: true
 argument-hint: "[--no-tests] [--no-security]"
 ---
 

--- a/src/ai_shell/templates/aider/conventions.md
+++ b/src/ai_shell/templates/aider/conventions.md
@@ -1,21 +1,42 @@
 # Project Conventions
 
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No manual versioning**: NEVER manually edit version numbers. Semantic Release manages versions via conventional commits.
+- **No lock file edits**: NEVER manually edit lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock).
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+
 ## Commit Messages
-- Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+- Conventional commits required: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+- Semantic versioning: `fix:` = patch, `feat:` = minor, `feat!:` = major
 - Keep the first line under 72 characters
 - Reference issues with `Refs #N` or `Closes #N`
 
 ## Branch Naming
-- Feature branches: `feat/issue-N-description`
-- Bug fixes: `fix/issue-N-description`
-- Documentation: `docs/description`
+
+- `{type}/issue-N-description` where type is: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf
 
 ## Code Style
+
 - Follow existing patterns in the codebase
-- Write tests for new functionality
-- Run linters before committing
+- Run `uv run pre-commit run --all-files` explicitly before committing (no automatic git hooks)
+- If pre-commit checks fail, fix and create a new commit (do not amend)
+
+## Development Commands
+
+```bash
+uv sync --all-extras                         # Install dependencies
+uv run pytest                                # Run tests
+uv run ruff check src/                       # Lint
+uv run mypy src/                             # Type check
+uv run pre-commit run --all-files            # Pre-commit hooks
+```
 
 ## Testing
+
 - All new features require unit tests
 - Bug fixes should include a regression test
 - Maintain test coverage above project threshold

--- a/src/ai_shell/templates/claude/skills/ai-create-cmd/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-create-cmd/SKILL.md
@@ -36,7 +36,6 @@ Follow these steps to create a well-structured skill:
    ---
    name: {skill-name}
    description: {One-line description of what it does and when to use it. Max 250 chars.}
-   disable-model-invocation: {true if skill has side effects, false otherwise}
    argument-hint: "[expected arguments]"
    ---
 
@@ -73,8 +72,6 @@ Follow these steps to create a well-structured skill:
    ```
 
 5. **Choose appropriate frontmatter options**:
-   - `disable-model-invocation: true` for skills with side effects (deploy, commit, push, delete)
-   - `disable-model-invocation: false` (default) for read-only or analysis skills
    - `argument-hint` to show expected arguments in the skill menu
    - Keep description under 250 characters, front-load key use case
 

--- a/src/ai_shell/templates/claude/skills/ai-monitor-pipeline/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-monitor-pipeline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-monitor-pipeline
 description: Monitor CI pipeline after push, diagnose failures, auto-fix and re-push. Use after submitting work or to check pipeline status.
-disable-model-invocation: true
 argument-hint: "[run-id or branch-name]"
 ---
 

--- a/src/ai_shell/templates/claude/skills/ai-promote/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-promote/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-promote
 description: Promote staging (dev) to production (main) by creating an automerge PR. Use when dev/staging is ready for release.
-disable-model-invocation: true
 ---
 
 Promote staging to production by creating an automerge PR from dev to main: $ARGUMENTS

--- a/src/ai_shell/templates/claude/skills/ai-repo-health/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-repo-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-repo-health
 description: Comprehensive repository health check with remote-first git hygiene, branch cleanup, and code quality analysis. Use for repo maintenance and cleanup.
-disable-model-invocation: true
 argument-hint: "[--remote-only] [--local-only] [--dry-run]"
 ---
 

--- a/src/ai_shell/templates/claude/skills/ai-submit-work/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-submit-work/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-submit-work
 description: Run all status checks locally, fix issues, commit, push, and create an automerge PR. Use when work is ready to submit.
-disable-model-invocation: true
 argument-hint: "[--no-tests] [--no-security]"
 ---
 

--- a/src/ai_shell/templates/codex/config.toml
+++ b/src/ai_shell/templates/codex/config.toml
@@ -21,7 +21,7 @@ sandbox = "workspace-write"
 [permissions.default.network]
 enabled = true
 mode = "limited"
-allowed_domains = ["api.github.com", "github.com"]
+allowed_domains = ["api.github.com", "github.com", "pypi.org", "files.pythonhosted.org", "registry.npmjs.org"]
 
 # Uncomment to add MCP servers
 # [mcp_servers.example]


### PR DESCRIPTION
## Summary
- Enrich AGENTS.md (opencode/codex) and CONVENTIONS.md (aider) with critical safety rules, dev commands, and conventions matching what Claude gets via CLAUDE.md
- Add pypi.org, files.pythonhosted.org, registry.npmjs.org to Codex network permissions
- Remove `disable-model-invocation: true` from 8 skill templates (4 claude, 4 agents) -- the flag was preventing the Skill tool from invoking them at all
- Document that pre-commit runs explicitly, not via automatic git hooks

## Test plan
- [x] `uv run python -m pytest tests/unit/test_scaffold.py -v` -- 50 passed
- [x] `uv run pre-commit run --all-files` -- all checks passed
- [ ] Run `ai-shell claude --clean` to verify updated templates deploy correctly
- [ ] Verify `/ai-submit-work` skill is now invocable via Skill tool