### PR TITLE
fix: resolve Codex skills/list TUI crash and validate tool configs

### DIFF
--- a/.claude/skills/ai-create-cmd/SKILL.md
+++ b/.claude/skills/ai-create-cmd/SKILL.md
@@ -36,7 +36,6 @@ Follow these steps to create a well-structured skill:
    ---
    name: {skill-name}
    description: {One-line description of what it does and when to use it. Max 250 chars.}
-   disable-model-invocation: {true if skill has side effects, false otherwise}
    argument-hint: "[expected arguments]"
    ---
 
@@ -73,8 +72,6 @@ Follow these steps to create a well-structured skill:
    ```
 
 5. **Choose appropriate frontmatter options**:
-   - `disable-model-invocation: true` for skills with side effects (deploy, commit, push, delete)
-   - `disable-model-invocation: false` (default) for read-only or analysis skills
    - `argument-hint` to show expected arguments in the skill menu
    - Keep description under 250 characters, front-load key use case
 

--- a/.claude/skills/ai-monitor-pipeline/SKILL.md
+++ b/.claude/skills/ai-monitor-pipeline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-monitor-pipeline
 description: Monitor CI pipeline after push, diagnose failures, auto-fix and re-push. Use after submitting work or to check pipeline status.
-disable-model-invocation: true
 argument-hint: "[run-id or branch-name]"
 ---
 

--- a/.claude/skills/ai-promote/SKILL.md
+++ b/.claude/skills/ai-promote/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-promote
 description: Promote staging (dev) to production (main) by creating an automerge PR. Use when dev/staging is ready for release.
-disable-model-invocation: true
 ---
 
 Promote staging to production by creating an automerge PR from dev to main: $ARGUMENTS

--- a/.claude/skills/ai-repo-health/SKILL.md
+++ b/.claude/skills/ai-repo-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-repo-health
 description: Comprehensive repository health check with remote-first git hygiene, branch cleanup, and code quality analysis. Use for repo maintenance and cleanup.
-disable-model-invocation: true
 argument-hint: "[--remote-only] [--local-only] [--dry-run]"
 ---
 

--- a/.claude/skills/ai-submit-work/SKILL.md
+++ b/.claude/skills/ai-submit-work/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-submit-work
 description: Run all status checks locally, fix issues, commit, push, and create an automerge PR. Use when work is ready to submit.
-disable-model-invocation: true
 argument-hint: "[--no-tests] [--no-security]"
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,51 +1,28 @@
-# CLAUDE.md - augint-shell
+# CLAUDE.md
 
-Python CLI tool for launching AI coding tools and local LLMs in Docker containers. Published to PyPI as `augint-shell`, CLI command is `ai-shell`.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## What This Tool Does
+## Overview
 
-Replaces Makefile + docker-compose.yml workflow:
-- Launch AI tools (Claude Code, Codex, opencode, aider) in Docker containers
-- Manage local LLM stack (Ollama + Open WebUI) with GPU auto-detection
-- Per-project containers with unique names for concurrent usage
-- Optional `ai-shell.toml` config for per-project customization
-
-## CLI Commands
-
-```bash
-# AI tools (each launches in a per-project Docker container)
-ai-shell claude            # Launch Claude Code
-ai-shell claude-x          # Claude with --dangerously-skip-permissions
-ai-shell codex             # Launch Codex
-ai-shell opencode          # Launch opencode
-ai-shell aider             # Launch aider with local LLM
-ai-shell shell             # Bash shell in container
-
-# LLM stack (host-level singletons)
-ai-shell llm up            # Start Ollama + Open WebUI
-ai-shell llm down          # Stop LLM stack
-ai-shell llm pull          # Pull models
-ai-shell llm setup         # First-time setup (up + pull + configure)
-ai-shell llm status        # Show status and models
-ai-shell llm logs          # Tail logs
-ai-shell llm shell         # Shell in Ollama container
-
-# Container management
-ai-shell manage status     # Show dev container status
-ai-shell manage stop       # Stop dev container
-ai-shell manage clean      # Remove container + volumes
-ai-shell manage logs       # Tail dev container logs
-ai-shell manage pull       # Pull latest Docker image
-```
+Python CLI tool (`ai-shell`) for launching AI coding tools and local LLMs in Docker containers. Published to PyPI as `augint-shell`. Replaces Makefile + docker-compose.yml workflow with per-project containers and optional `ai-shell.toml` config.
 
 ## Development
 
 ```bash
-uv sync --all-extras
-uv run pytest
-uv run ruff check src/
-uv run mypy src/
+uv sync --all-extras                       # Install all deps
+uv run pytest                              # All tests
+uv run pytest tests/unit/test_config.py    # Single test file
+uv run pytest -k "test_load_missing"       # Single test by name
+uv run pytest --cov=src --cov-fail-under=80  # With coverage
+uv run ruff check src/                     # Lint
+uv run ruff format src/ tests/             # Format
+uv run mypy src/                           # Type check
+uv run pre-commit run --all-files          # All pre-commit hooks
 ```
+
+## Pre-commit Hooks
+
+Hooks run automatically: YAML check, trailing whitespace, end-of-file newline, `.env` file blocker, ruff format + lint (with auto-fix), mypy, and uv.lock freshness check.
 
 ## CRITICAL: No Rebase on Main
 
@@ -56,33 +33,59 @@ uv run mypy src/
 **NEVER manually edit version numbers.** Python Semantic Release owns versioning.
 
 - Version in `pyproject.toml` and `src/ai_shell/__init__.py`
-- Bumped automatically via conventional commits:
-  - `fix:` -> patch
-  - `feat:` -> minor
-  - `feat!:` -> major
+- Bumped automatically via conventional commits: `fix:` (patch), `feat:` (minor), `feat!:` (major)
 - Tag format: `augint-shell-v{version}`
 
-## Testing
+## Architecture
 
-```bash
-uv run pytest                              # All tests
-uv run pytest --cov=src --cov-fail-under=80  # With coverage
-```
-
-## File Structure
+### Dependency Flow
 
 ```
-src/ai_shell/
-├── __init__.py       # Version, public exports
-├── defaults.py       # Constants, mount/env builders
-├── config.py         # TOML config loading
-├── container.py      # Docker SDK container lifecycle
-├── gpu.py            # NVIDIA GPU detection
-├── exceptions.py     # Error hierarchy
-└── cli/
-    ├── __main__.py   # Click entry point
-    └── commands/
-        ├── tools.py  # claude, codex, opencode, aider, shell
-        ├── llm.py    # llm up/down/pull/setup/status/logs/shell
-        └── manage.py # manage stop/clean/status/logs/pull
+CLI commands (cli/commands/)
+  -> ContainerManager (container.py)
+    -> AiShellConfig (config.py)
+    -> defaults.py (constants, mount/env builders)
+    -> gpu.py (NVIDIA detection)
 ```
+
+### Two Container Categories
+
+1. **Per-project dev containers** (`augint-shell-{project}-dev`): One per project directory, runs all AI tools. Created on-demand, reused if running. Uses `tail -f /dev/null` to stay alive, commands exec into it.
+
+2. **Host-level LLM stack** (singletons): Ollama + Open WebUI containers shared across all projects via `augint-shell-llm` Docker network. Persistent named volumes. GPU auto-detected for Ollama.
+
+### Config Layering (highest priority first)
+
+1. CLI flags (`--project`)
+2. Environment variables (`AI_SHELL_*` prefix)
+3. Project `ai-shell.toml`
+4. Global `~/.config/ai-shell/config.toml`
+5. Hard-coded defaults in `defaults.py`
+
+### Container Naming
+
+`project_dir.name` -> `sanitize_project_name()` (lowercase, special chars to hyphens, collapsed) -> `dev_container_name()` -> `augint-shell-{name}-dev`. Override with `--project` flag.
+
+### Mount Assembly
+
+Dev containers mount: project dir, UV cache volume (shared), and conditionally: `~/.claude`, `~/.codex`, `~/.ssh` (ro), `~/.aws`, `~/.gitconfig` (ro), `~/projects/CLAUDE.md` (ro), Docker socket (ro), plus `extra_volumes` from config.
+
+### Environment Assembly
+
+Priority: `extra_env` > `.env` file > `os.environ` > defaults. AWS IAM keys are intentionally NOT passed through (only `AWS_PROFILE` + `AWS_REGION`; relies on `~/.aws` bind mount). `IS_SANDBOX=1` is always set.
+
+### Claude Retry Logic
+
+Default: runs with `-c` (continue previous conversation). If it fails fast (< 5 seconds), retries without `-c` (assumes no prior conversation exists).
+
+### Scaffold System
+
+`ai-shell init` and per-tool `--init`/`--update`/`--clean` flags write tool config files (`.claude/`, `.codex/`, `.agents/`, etc.) into the project. `--clean` removes all managed paths then recreates them fresh.
+
+## CI/CD Pipeline
+
+PR pipeline: pre-commit -> (security scan + compliance + unit tests in parallel). On merge to main: semantic-release -> (PyPI publish + Docker Hub publish + GitHub Pages docs deploy in parallel).
+
+## Testing Patterns
+
+All tests are unit tests in `tests/unit/`. Docker SDK is mocked via fixtures in `conftest.py` (`mock_docker_client`, `mock_container_manager`). CLI tests use Click's `CliRunner` with patched `ContainerManager` and `load_config`. Tests verify command argument building and container creation kwargs, not actual Docker operations.

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -114,7 +114,7 @@ def codex(ctx, do_init, do_update, do_clean, safe, extra_args):
     cmd = ["codex"]
     if not safe:
         cmd.extend(["--dangerously-bypass-approvals-and-sandbox"])
-    cmd.extend(["--search", *extra_args])
+    cmd.extend(extra_args)
     console.print(f"[bold]Launching Codex{' (safe mode)' if safe else ''} in {name}...[/bold]")
     manager.exec_interactive(name, cmd)
 

--- a/src/ai_shell/templates/agents/agents.md
+++ b/src/ai_shell/templates/agents/agents.md
@@ -4,32 +4,53 @@
 
 <!-- Describe your project here. This file is read automatically by Codex and opencode. -->
 
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No manual versioning**: NEVER manually edit version numbers. Semantic Release manages versions via conventional commits.
+- **No lock file edits**: NEVER manually edit lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock). They are auto-generated.
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+
+## Development Commands
+
+```bash
+uv sync --all-extras                         # Install dependencies
+uv run pytest                                # Run tests
+uv run pytest --cov=src --cov-fail-under=80  # Tests with coverage
+uv run ruff check src/                       # Lint
+uv run mypy src/                             # Type check
+uv run pre-commit run --all-files            # Run all pre-commit hooks
+```
+
+## Conventions
+
+- **Commits**: Conventional commits required. `fix:` = patch, `feat:` = minor, `feat!:` / `BREAKING CHANGE` = major.
+- **Branches**: `{type}/issue-N-description` where type is one of: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf.
+- **PRs**: Target the default development branch. Enable automerge.
+- **Pre-commit**: Run `uv run pre-commit run --all-files` explicitly before committing (no automatic git hooks -- they break across Windows/WSL). If checks fail, fix the issue and create a NEW commit (do not amend).
+- **Tests**: Write tests for all new functionality. Bug fixes require regression tests.
+
 ## Development Workflow
 
 1. **Pick an issue**: Find or get assigned an issue to work on
 2. **Create a branch**: `git checkout -b feat/issue-N-description`
 3. **Develop**: Write code with tests, following project conventions
-4. **Submit**: Run checks, commit with conventional messages, create PR
-5. **Monitor**: Watch CI pipeline, fix any failures
-6. **Merge**: PR auto-merges after checks pass
-
-## Conventions
-
-- **Commits**: Use conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`)
-- **Branches**: `{feat|fix|docs}/issue-N-description`
-- **PRs**: Target the default development branch, enable automerge
-- **Tests**: Write tests for all new functionality
+4. **Check**: Run `uv run pre-commit run --all-files` and `uv run pytest`
+5. **Submit**: Commit with conventional messages, create PR
+6. **Monitor**: Watch CI pipeline, fix any failures
 
 ## Key Commands
 
 ```bash
-# Development
+# Git
 git status                    # Check working tree
+git log --oneline -10         # Recent commits
+
+# GitHub CLI
 gh issue list --state open    # View open issues
 gh pr create                  # Create pull request
 gh pr merge --auto --squash   # Enable automerge
-
-# CI/CD
 gh run list                   # List workflow runs
 gh run view <id>              # View run details
 gh run watch <id>             # Watch run in real-time

--- a/src/ai_shell/templates/agents/skills/ai-monitor-pipeline/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-monitor-pipeline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-monitor-pipeline
 description: Monitor CI pipeline after push, diagnose failures, auto-fix and re-push. Use after submitting work or to check pipeline status.
-disable-model-invocation: true
 argument-hint: "[run-id or branch-name]"
 ---
 

--- a/src/ai_shell/templates/agents/skills/ai-promote/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-promote/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-promote
 description: Promote staging (dev) to production (main) by creating an automerge PR. Use when dev/staging is ready for release.
-disable-model-invocation: true
 ---
 
 Promote staging to production by creating an automerge PR from dev to main: $ARGUMENTS

--- a/src/ai_shell/templates/agents/skills/ai-repo-health/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-repo-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-repo-health
 description: Comprehensive repository health check with remote-first git hygiene, branch cleanup, and code quality analysis. Use for repo maintenance and cleanup.
-disable-model-invocation: true
 argument-hint: "[--remote-only] [--local-only] [--dry-run]"
 ---
 

--- a/src/ai_shell/templates/agents/skills/ai-submit-work/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-submit-work/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-submit-work
 description: Run all status checks locally, fix issues, commit, push, and create an automerge PR. Use when work is ready to submit.
-disable-model-invocation: true
 argument-hint: "[--no-tests] [--no-security]"
 ---
 

--- a/src/ai_shell/templates/aider/aider.conf.yml
+++ b/src/ai_shell/templates/aider/aider.conf.yml
@@ -1,5 +1,5 @@
 # Aider configuration
-# See: https://aider.chat/docs/config/adr_conf.html
+# See: https://aider.chat/docs/config/aider_conf.html
 # Every CLI flag maps to a YAML key (use dashes, not underscores).
 
 # Model selection

--- a/src/ai_shell/templates/aider/conventions.md
+++ b/src/ai_shell/templates/aider/conventions.md
@@ -1,21 +1,42 @@
 # Project Conventions
 
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No manual versioning**: NEVER manually edit version numbers. Semantic Release manages versions via conventional commits.
+- **No lock file edits**: NEVER manually edit lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock).
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+
 ## Commit Messages
-- Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+- Conventional commits required: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+- Semantic versioning: `fix:` = patch, `feat:` = minor, `feat!:` = major
 - Keep the first line under 72 characters
 - Reference issues with `Refs #N` or `Closes #N`
 
 ## Branch Naming
-- Feature branches: `feat/issue-N-description`
-- Bug fixes: `fix/issue-N-description`
-- Documentation: `docs/description`
+
+- `{type}/issue-N-description` where type is: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf
 
 ## Code Style
+
 - Follow existing patterns in the codebase
-- Write tests for new functionality
-- Run linters before committing
+- Run `uv run pre-commit run --all-files` explicitly before committing (no automatic git hooks)
+- If pre-commit checks fail, fix and create a new commit (do not amend)
+
+## Development Commands
+
+```bash
+uv sync --all-extras                         # Install dependencies
+uv run pytest                                # Run tests
+uv run ruff check src/                       # Lint
+uv run mypy src/                             # Type check
+uv run pre-commit run --all-files            # Pre-commit hooks
+```
 
 ## Testing
+
 - All new features require unit tests
 - Bug fixes should include a regression test
 - Maintain test coverage above project threshold

--- a/src/ai_shell/templates/claude/skills/ai-create-cmd/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-create-cmd/SKILL.md
@@ -36,7 +36,6 @@ Follow these steps to create a well-structured skill:
    ---
    name: {skill-name}
    description: {One-line description of what it does and when to use it. Max 250 chars.}
-   disable-model-invocation: {true if skill has side effects, false otherwise}
    argument-hint: "[expected arguments]"
    ---
 
@@ -73,8 +72,6 @@ Follow these steps to create a well-structured skill:
    ```
 
 5. **Choose appropriate frontmatter options**:
-   - `disable-model-invocation: true` for skills with side effects (deploy, commit, push, delete)
-   - `disable-model-invocation: false` (default) for read-only or analysis skills
    - `argument-hint` to show expected arguments in the skill menu
    - Keep description under 250 characters, front-load key use case
 

--- a/src/ai_shell/templates/claude/skills/ai-monitor-pipeline/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-monitor-pipeline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-monitor-pipeline
 description: Monitor CI pipeline after push, diagnose failures, auto-fix and re-push. Use after submitting work or to check pipeline status.
-disable-model-invocation: true
 argument-hint: "[run-id or branch-name]"
 ---
 

--- a/src/ai_shell/templates/claude/skills/ai-promote/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-promote/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-promote
 description: Promote staging (dev) to production (main) by creating an automerge PR. Use when dev/staging is ready for release.
-disable-model-invocation: true
 ---
 
 Promote staging to production by creating an automerge PR from dev to main: $ARGUMENTS

--- a/src/ai_shell/templates/claude/skills/ai-repo-health/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-repo-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-repo-health
 description: Comprehensive repository health check with remote-first git hygiene, branch cleanup, and code quality analysis. Use for repo maintenance and cleanup.
-disable-model-invocation: true
 argument-hint: "[--remote-only] [--local-only] [--dry-run]"
 ---
 

--- a/src/ai_shell/templates/claude/skills/ai-submit-work/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-submit-work/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ai-submit-work
 description: Run all status checks locally, fix issues, commit, push, and create an automerge PR. Use when work is ready to submit.
-disable-model-invocation: true
 argument-hint: "[--no-tests] [--no-security]"
 ---
 

--- a/src/ai_shell/templates/codex/config.toml
+++ b/src/ai_shell/templates/codex/config.toml
@@ -21,7 +21,7 @@ sandbox = "workspace-write"
 [permissions.default.network]
 enabled = true
 mode = "limited"
-allowed_domains = ["api.github.com", "github.com"]
+allowed_domains = ["api.github.com", "github.com", "pypi.org", "files.pythonhosted.org", "registry.npmjs.org"]
 
 # Uncomment to add MCP servers
 # [mcp_servers.example]

--- a/src/ai_shell/templates/codex/config.toml
+++ b/src/ai_shell/templates/codex/config.toml
@@ -11,6 +11,7 @@ approval_policy = "on-request"
 # Sandbox mode controls technical boundaries.
 # Options: "read-only" | "workspace-write" | "danger-full-access"
 sandbox = "workspace-write"
+default_permissions = "default"
 
 # Named permissions profile
 [permissions.default]

--- a/src/ai_shell/templates/codex/config.toml
+++ b/src/ai_shell/templates/codex/config.toml
@@ -2,6 +2,7 @@
 # See: https://developers.openai.com/codex/config-reference
 
 model = "o4-mini"
+web_search = "live"
 
 # Approval policy controls when Codex asks for confirmation.
 # Options: "untrusted" | "on-request" | "never"

--- a/src/ai_shell/templates/opencode/opencode.json
+++ b/src/ai_shell/templates/opencode/opencode.json
@@ -28,7 +28,6 @@
   "permission": {
     "read": "allow",
     "edit": "allow",
-    "write": "allow",
     "glob": "allow",
     "grep": "allow",
     "list": "allow",

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -94,7 +94,6 @@ class TestToolCommands:
         cmd = mock_manager.exec_interactive.call_args[0][1]
         assert "codex" in cmd
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
-        assert "--search" in cmd
 
     def test_codex_safe_mode(self, mock_config, mock_manager_cls):
         mock_manager = MagicMock()
@@ -106,7 +105,6 @@ class TestToolCommands:
 
         cmd = mock_manager.exec_interactive.call_args[0][1]
         assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
-        assert "--search" in cmd
 
     def test_shell_command(self, mock_config, mock_manager_cls):
         mock_manager = MagicMock()


### PR DESCRIPTION
## Summary
- Add missing `default_permissions = "default"` to Codex `config.toml` template -- this was the root cause of `Error: skills/list failed in TUI`
- Move live web search from `--search` CLI flag to `web_search = "live"` in config (the flag caused the skills/list RPC to fail inside Docker)
- Remove invalid `write` permission from opencode.json (`edit` already covers it)
- Fix broken documentation URL in aider config template
- Remove `disable-model-invocation` flag from skills (blocks Skill tool invocation)

## Test plan
- [x] `uv run pytest tests/unit/test_cli_tools.py tests/unit/test_scaffold.py -v` -- 70 tests pass
- [x] `uv run pre-commit run --all-files` -- all hooks pass
- [ ] Rebuild Docker image and run `ai-shell codex` in a project to confirm TUI loads
- [ ] Run `ai-shell codex --update` in existing project to pick up new config