### PR TITLE
feat(scaffold): add repo-type flags and monorepo skill support

### DIFF
--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -1,6 +1,9 @@
 """AI tool subcommands: claude, codex, opencode, aider, shell."""
 
+from __future__ import annotations
+
 import sys
+import tomllib
 from pathlib import Path
 
 import click
@@ -9,10 +12,96 @@ from rich.console import Console
 from ai_shell.config import load_config
 from ai_shell.container import ContainerManager
 from ai_shell.defaults import build_dev_environment
+from ai_shell.scaffold import BranchStrategy, RepoType
 
 console = Console(stderr=True)
 
 FAST_FAILURE_THRESHOLD = 5.0  # seconds — if claude -c exits faster, retry without -c
+
+
+# ── Repo-type resolution helpers ──────────────────────────────────
+
+
+def _read_persisted_project(target_dir: Path) -> dict[str, str]:
+    """Read [project] section from existing ai-shell.toml, if any."""
+    try:
+        toml_path = target_dir / "ai-shell.toml"
+        if not toml_path.exists():
+            return {}
+        with open(toml_path, "rb") as f:
+            data = tomllib.load(f)
+        result: dict[str, str] = data.get("project", {})
+        return result
+    except (OSError, tomllib.TOMLDecodeError, TypeError):
+        return {}
+
+
+def _prompt_repo_config() -> tuple[RepoType, BranchStrategy, str]:
+    """Interactively ask user for repo type and branch strategy."""
+    repo_type_val = click.prompt(
+        "Repo type",
+        type=click.Choice(["library", "iac", "monorepo"], case_sensitive=False),
+    )
+    branch_val = click.prompt(
+        "Branch strategy",
+        type=click.Choice(["main", "dev"], case_sensitive=False),
+        default="main",
+    )
+    dev_branch = "dev"
+    if branch_val == "dev":
+        dev_branch = click.prompt("Dev branch name", default="dev")
+    return RepoType(repo_type_val), BranchStrategy(branch_val), dev_branch
+
+
+def _resolve_repo_config(
+    flag: str | None,
+    target_dir: Path,
+    *,
+    prompt_if_missing: bool = False,
+) -> tuple[RepoType | None, BranchStrategy | None, str]:
+    """Resolve repo type / branch strategy from flag, config, or prompt.
+
+    Returns (repo_type, branch_strategy, dev_branch).
+    """
+    # 1. CLI flag wins
+    if flag:
+        repo_type = RepoType(flag)
+        # When flag is given without existing config, prompt for branch strategy
+        persisted = _read_persisted_project(target_dir)
+        if "branch_strategy" in persisted:
+            branch_strategy = BranchStrategy(persisted["branch_strategy"])
+            dev_branch = persisted.get("dev_branch", "dev")
+        elif prompt_if_missing:
+            branch_val = click.prompt(
+                "Branch strategy",
+                type=click.Choice(["main", "dev"], case_sensitive=False),
+                default="main",
+            )
+            branch_strategy = BranchStrategy(branch_val)
+            dev_branch = "dev"
+            if branch_strategy == BranchStrategy.DEV:
+                dev_branch = click.prompt("Dev branch name", default="dev")
+        else:
+            branch_strategy = None
+            dev_branch = "dev"
+        return repo_type, branch_strategy, dev_branch
+
+    # 2. Existing ai-shell.toml [project] section
+    persisted = _read_persisted_project(target_dir)
+    if "repo_type" in persisted:
+        repo_type = RepoType(persisted["repo_type"])
+        branch_strategy = (
+            BranchStrategy(persisted["branch_strategy"]) if "branch_strategy" in persisted else None
+        )
+        dev_branch = persisted.get("dev_branch", "dev")
+        return repo_type, branch_strategy, dev_branch
+
+    # 3. Interactive prompt (only for init, not for update/reset without flag)
+    if prompt_if_missing:
+        return _prompt_repo_config()
+
+    # 4. No config available
+    return None, None, "dev"
 
 
 def _get_manager(ctx) -> tuple[ContainerManager, str, dict[str, str]]:
@@ -67,18 +156,30 @@ def _get_manager(ctx) -> tuple[ContainerManager, str, dict[str, str]]:
     default=False,
     help="Skip merging notes into context file on --update/--reset.",
 )
+@click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
+@click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
+@click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def claude(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, extra_args):
+def claude(
+    ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, repo_type_flag, extra_args
+):
     """Launch Claude Code in the dev container."""
     if do_init or do_update or do_reset or do_clean:
         from ai_shell.scaffold import scaffold_claude as _scaffold_claude
 
+        target_dir = Path.cwd()
+        repo_type, branch_strategy, _dev = _resolve_repo_config(
+            repo_type_flag,
+            target_dir,
+        )
         _scaffold_claude(
-            Path.cwd(),
+            target_dir,
             overwrite=do_reset or do_clean,
             clean=do_clean,
             merge=do_update,
+            repo_type=repo_type,
+            branch_strategy=branch_strategy,
         )
         if (do_update or do_reset) and not skip_merge:
             from ai_shell.notes_merge import merge_notes_into_context
@@ -144,18 +245,30 @@ def claude(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, extra_
     default=False,
     help="Skip merging notes into context file on --update/--reset.",
 )
+@click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
+@click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
+@click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def codex(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, extra_args):
+def codex(
+    ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, repo_type_flag, extra_args
+):
     """Launch Codex in the dev container."""
     if do_init or do_update or do_reset or do_clean:
         from ai_shell.scaffold import scaffold_codex as _scaffold_codex
 
+        target_dir = Path.cwd()
+        repo_type, branch_strategy, _dev = _resolve_repo_config(
+            repo_type_flag,
+            target_dir,
+        )
         _scaffold_codex(
-            Path.cwd(),
+            target_dir,
             overwrite=do_reset or do_clean,
             clean=do_clean,
             merge=do_update,
+            repo_type=repo_type,
+            branch_strategy=branch_strategy,
         )
         if (do_update or do_reset) and not skip_merge:
             from ai_shell.notes_merge import merge_notes_into_context
@@ -209,17 +322,27 @@ def codex(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, extra_a
     default=False,
     help="Skip merging notes into context file on --update/--reset.",
 )
+@click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
+@click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
+@click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
 @click.pass_context
-def opencode(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge):
+def opencode(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, repo_type_flag):
     """Launch opencode in the dev container."""
     if do_init or do_update or do_reset or do_clean:
         from ai_shell.scaffold import scaffold_opencode as _scaffold_opencode
 
+        target_dir = Path.cwd()
+        repo_type, branch_strategy, _dev = _resolve_repo_config(
+            repo_type_flag,
+            target_dir,
+        )
         _scaffold_opencode(
-            Path.cwd(),
+            target_dir,
             overwrite=do_reset or do_clean,
             clean=do_clean,
             merge=do_update,
+            repo_type=repo_type,
+            branch_strategy=branch_strategy,
         )
         if (do_update or do_reset) and not skip_merge:
             from ai_shell.notes_merge import merge_notes_into_context
@@ -263,18 +386,27 @@ def opencode(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge):
     help="Delete and recreate aider config from templates.",
 )
 @click.option("--safe", is_flag=True, default=False, help="Run without permissive flags.")
+@click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
+@click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
+@click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def aider(ctx, do_init, do_update, do_reset, do_clean, safe, extra_args):
+def aider(ctx, do_init, do_update, do_reset, do_clean, safe, repo_type_flag, extra_args):
     """Launch aider with local LLM in the dev container."""
     if do_init or do_update or do_reset or do_clean:
         from ai_shell.scaffold import scaffold_aider as _scaffold_aider
 
+        target_dir = Path.cwd()
+        repo_type, _branch, _dev = _resolve_repo_config(
+            repo_type_flag,
+            target_dir,
+        )
         _scaffold_aider(
-            Path.cwd(),
+            target_dir,
             overwrite=do_reset or do_clean,
             clean=do_clean,
             merge=do_update,
+            repo_type=repo_type,
         )
         return
 
@@ -332,7 +464,24 @@ def shell(ctx):
     default=False,
     help="Skip merging notes into context files on --update/--reset --all.",
 )
-def init(update, reset, clean, scaffold_all, skip_merge):
+@click.option(
+    "--lib",
+    "--library",
+    "repo_type_flag",
+    flag_value="library",
+    help="Scaffold for a library repo (publishes packages).",
+)
+@click.option(
+    "--iac", "repo_type_flag", flag_value="iac", help="Scaffold for an IaC / web / backend repo."
+)
+@click.option(
+    "--mono",
+    "--monorepo",
+    "repo_type_flag",
+    flag_value="monorepo",
+    help="Scaffold for a monorepo (git submodules).",
+)
+def init(update, reset, clean, scaffold_all, skip_merge, repo_type_flag):
     """Initialize ai-shell config files in the current directory."""
     from ai_shell.scaffold import scaffold_aider as _scaffold_aider
     from ai_shell.scaffold import scaffold_claude as _scaffold_claude
@@ -342,14 +491,60 @@ def init(update, reset, clean, scaffold_all, skip_merge):
 
     overwrite = reset or clean
     merge = update
-    scaffold_project(Path.cwd(), overwrite=overwrite, clean=clean, merge=merge)
+    target_dir = Path.cwd()
+
+    # Resolve repo type: flag > persisted config > interactive prompt
+    # Prompt only on fresh init (not update/reset without explicit flag)
+    is_fresh_init = not (update or reset or clean)
+    repo_type, branch_strategy, dev_branch = _resolve_repo_config(
+        repo_type_flag,
+        target_dir,
+        prompt_if_missing=is_fresh_init,
+    )
+
+    scaffold_project(
+        target_dir,
+        overwrite=overwrite,
+        clean=clean,
+        merge=merge,
+        repo_type=repo_type,
+        branch_strategy=branch_strategy,
+        dev_branch=dev_branch,
+    )
     if scaffold_all:
-        _scaffold_claude(Path.cwd(), overwrite=overwrite, clean=clean, merge=merge)
-        _scaffold_opencode(Path.cwd(), overwrite=overwrite, clean=clean, merge=merge)
-        _scaffold_codex(Path.cwd(), overwrite=overwrite, clean=clean, merge=merge)
-        _scaffold_aider(Path.cwd(), overwrite=overwrite, clean=clean, merge=merge)
+        _scaffold_claude(
+            target_dir,
+            overwrite=overwrite,
+            clean=clean,
+            merge=merge,
+            repo_type=repo_type,
+            branch_strategy=branch_strategy,
+        )
+        _scaffold_opencode(
+            target_dir,
+            overwrite=overwrite,
+            clean=clean,
+            merge=merge,
+            repo_type=repo_type,
+            branch_strategy=branch_strategy,
+        )
+        _scaffold_codex(
+            target_dir,
+            overwrite=overwrite,
+            clean=clean,
+            merge=merge,
+            repo_type=repo_type,
+            branch_strategy=branch_strategy,
+        )
+        _scaffold_aider(
+            target_dir,
+            overwrite=overwrite,
+            clean=clean,
+            merge=merge,
+            repo_type=repo_type,
+        )
         if (update or reset) and not skip_merge:
             from ai_shell.notes_merge import merge_notes_into_context
 
-            merge_notes_into_context(Path.cwd(), "claude", background=True)
-            merge_notes_into_context(Path.cwd(), "codex", background=True)
+            merge_notes_into_context(target_dir, "claude", background=True)
+            merge_notes_into_context(target_dir, "codex", background=True)

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -50,6 +50,11 @@ class AiShellConfig:
     extra_volumes: list[str] = field(default_factory=list)
     extra_ports: list[int] = field(default_factory=list)
 
+    # Project workflow
+    repo_type: str | None = None  # "library" | "iac" | "monorepo"
+    branch_strategy: str | None = None  # "main" | "dev"
+    dev_branch: str = "dev"
+
     @property
     def full_image(self) -> str:
         """Return the full image reference with tag."""
@@ -141,6 +146,15 @@ def _apply_toml(config: AiShellConfig, path: Path) -> None:
     aider = data.get("aider", {})
     if "model" in aider:
         config.aider_model = aider["model"]
+
+    # [project] section
+    project = data.get("project", {})
+    if "repo_type" in project:
+        config.repo_type = project["repo_type"]
+    if "branch_strategy" in project:
+        config.branch_strategy = project["branch_strategy"]
+    if "dev_branch" in project:
+        config.dev_branch = project["dev_branch"]
 
 
 def _apply_env_vars(config: AiShellConfig) -> None:

--- a/src/ai_shell/scaffold.py
+++ b/src/ai_shell/scaffold.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+from enum import StrEnum
 from importlib import resources
 from pathlib import Path
 
@@ -63,14 +64,25 @@ _PROJECT_FILES = ["ai-shell.toml"]
 _NOTES_FILE = "NOTES.md"
 
 
-def _write_notes(target_dir: Path) -> None:
+def _write_notes(target_dir: Path, repo_type: RepoType | None = None) -> None:
     """Create NOTES.md if it does not exist. Never overwrite or delete."""
     path = target_dir / _NOTES_FILE
     if path.exists():
         console.print(f"[yellow]Skipped (protected): {path}[/yellow]")
         return
-    path.write_text(_read_template("notes.md"), encoding="utf-8", newline="\n")
+    template_name = _NOTES_TEMPLATE.get(repo_type, "notes.md")
+    path.write_text(_read_template(template_name), encoding="utf-8", newline="\n")
     console.print(f"[green]Created: {path}[/green]")
+
+
+def _remove_stale_skills(skills_dir: Path, active_skills: list[str]) -> None:
+    """Remove skill directories that are no longer applicable for the repo type."""
+    for skill_name in ALL_KNOWN_SKILLS:
+        if skill_name not in active_skills:
+            path = skills_dir / skill_name
+            if path.exists():
+                shutil.rmtree(path)
+                console.print(f"[red]Removed (not applicable): {path}[/red]")
 
 
 def _deep_merge_settings(existing: dict, template: dict) -> dict:
@@ -132,6 +144,86 @@ def _write_file(path: Path, content: str, *, overwrite: bool) -> bool:
     return True
 
 
+# ── Repo type / branch strategy enums ─────────────────────────────
+
+
+class RepoType(StrEnum):
+    LIBRARY = "library"
+    IAC = "iac"
+    MONOREPO = "monorepo"
+
+
+class BranchStrategy(StrEnum):
+    MAIN = "main"
+    DEV = "dev"
+
+
+# ── Skill sets ────────────────────────────────────────────────────
+
+_UNIVERSAL_SKILLS = [
+    "ai-pick-issue",
+    "ai-prepare-branch",
+    "ai-submit-work",
+    "ai-monitor-pipeline",
+    "ai-status",
+    "ai-rollback",
+    "ai-repo-health",
+    "ai-create-cmd",
+    "ai-web-dev",
+    "ai-standardize-pipeline",
+    "ai-standardize-precommit",
+    "ai-standardize-dotfiles",
+    "ai-standardize-repo",
+]
+
+_RELEASE_SKILLS = ["ai-standardize-renovate", "ai-standardize-release"]
+_PROMOTE_SKILLS = ["ai-promote"]
+_IAC_SKILLS = ["ai-setup-oidc"]
+_MONO_SKILLS = [
+    "ai-mono-status",
+    "ai-mono-sync",
+    "ai-mono-init",
+    "ai-mono-health",
+    "ai-mono-foreach",
+]
+
+
+def skills_for_config(
+    repo_type: RepoType | None,
+    branch_strategy: BranchStrategy | None,
+) -> list[str]:
+    """Return the skill list for a given repo type and branch strategy."""
+    if repo_type is None:
+        return list(CLAUDE_SKILL_DIRS)
+
+    skills = list(_UNIVERSAL_SKILLS)
+
+    if repo_type != RepoType.MONOREPO:
+        skills.extend(_RELEASE_SKILLS)
+    if repo_type == RepoType.IAC:
+        skills.extend(_IAC_SKILLS)
+    if repo_type == RepoType.MONOREPO:
+        skills.extend(_MONO_SKILLS)
+    if branch_strategy == BranchStrategy.DEV:
+        skills.extend(_PROMOTE_SKILLS)
+
+    return skills
+
+
+# All known skill names (superset for stale-skill cleanup).
+ALL_KNOWN_SKILLS = sorted(
+    set(_UNIVERSAL_SKILLS + _RELEASE_SKILLS + _PROMOTE_SKILLS + _IAC_SKILLS + _MONO_SKILLS)
+)
+
+# NOTES.md template mapping by repo type.
+_NOTES_TEMPLATE: dict[RepoType | None, str] = {
+    None: "notes.md",
+    RepoType.LIBRARY: "notes-library.md",
+    RepoType.IAC: "notes-iac.md",
+    RepoType.MONOREPO: "notes-monorepo.md",
+}
+
+
 # ── Public API ──────────────────────────────────────────────────────
 
 CLAUDE_SKILL_DIRS = [
@@ -161,6 +253,8 @@ def scaffold_claude(
     overwrite: bool = False,
     clean: bool = False,
     merge: bool = False,
+    repo_type: RepoType | None = None,
+    branch_strategy: BranchStrategy | None = None,
 ) -> None:
     """Create ``.claude/`` directory with settings and skills."""
     if clean:
@@ -182,17 +276,42 @@ def scaffold_claude(
         )
 
     # skill files
-    for skill_name in CLAUDE_SKILL_DIRS:
+    active_skills = skills_for_config(repo_type, branch_strategy)
+    for skill_name in active_skills:
         _write_file(
             skills_dir / skill_name / "SKILL.md",
             _read_template("claude", "skills", skill_name, "SKILL.md"),
             overwrite=effective_overwrite,
         )
 
+    # Remove skills that no longer apply (e.g. after repo type change)
+    if repo_type is not None:
+        _remove_stale_skills(skills_dir, active_skills)
+
     console.print("[bold green]Claude configuration ready.[/bold green]")
 
 
 AGENTS_SKILL_DIRS = list(CLAUDE_SKILL_DIRS)  # Mirrored to .agents/skills/
+
+
+def _build_toml_content(
+    repo_type: RepoType | None,
+    branch_strategy: BranchStrategy | None,
+    dev_branch: str = "dev",
+) -> str:
+    """Build ai-shell.toml content, prepending [project] section if configured."""
+    base = _read_template("ai-shell.toml")
+    if repo_type is None:
+        return base
+
+    lines = ["[project]", f'repo_type = "{repo_type.value}"']
+    if branch_strategy is not None:
+        lines.append(f'branch_strategy = "{branch_strategy.value}"')
+    if branch_strategy == BranchStrategy.DEV:
+        lines.append(f'dev_branch = "{dev_branch}"')
+    lines.append("")  # blank separator
+
+    return "\n".join(lines) + "\n" + base
 
 
 def scaffold_project(
@@ -201,6 +320,9 @@ def scaffold_project(
     overwrite: bool = False,
     clean: bool = False,
     merge: bool = False,
+    repo_type: RepoType | None = None,
+    branch_strategy: BranchStrategy | None = None,
+    dev_branch: str = "dev",
 ) -> None:
     """Create ``ai-shell.toml`` in *target_dir*."""
     if clean:
@@ -209,11 +331,11 @@ def scaffold_project(
     effective_overwrite = overwrite or merge
     _write_file(
         target_dir / "ai-shell.toml",
-        _read_template("ai-shell.toml"),
+        _build_toml_content(repo_type, branch_strategy, dev_branch),
         overwrite=effective_overwrite,
     )
 
-    _write_notes(target_dir)
+    _write_notes(target_dir, repo_type=repo_type)
     console.print("[bold green]Project configuration ready.[/bold green]")
 
 
@@ -223,6 +345,8 @@ def scaffold_opencode(
     overwrite: bool = False,
     clean: bool = False,
     merge: bool = False,
+    repo_type: RepoType | None = None,
+    branch_strategy: BranchStrategy | None = None,
 ) -> None:
     """Create opencode configuration, NOTES.md, and ``.agents/skills/``."""
     if clean:
@@ -238,14 +362,19 @@ def scaffold_opencode(
             opencode_template,
             overwrite=overwrite,
         )
-    for skill_name in AGENTS_SKILL_DIRS:
+    active_skills = skills_for_config(repo_type, branch_strategy)
+    skills_dir = target_dir / ".agents" / "skills"
+    for skill_name in active_skills:
         _write_file(
-            target_dir / ".agents" / "skills" / skill_name / "SKILL.md",
+            skills_dir / skill_name / "SKILL.md",
             _read_template("agents", "skills", skill_name, "SKILL.md"),
             overwrite=effective_overwrite,
         )
 
-    _write_notes(target_dir)
+    if repo_type is not None:
+        _remove_stale_skills(skills_dir, active_skills)
+
+    _write_notes(target_dir, repo_type=repo_type)
     console.print("[bold green]opencode configuration ready.[/bold green]")
 
 
@@ -255,6 +384,8 @@ def scaffold_codex(
     overwrite: bool = False,
     clean: bool = False,
     merge: bool = False,
+    repo_type: RepoType | None = None,
+    branch_strategy: BranchStrategy | None = None,
 ) -> None:
     """Create ``.codex/`` config, NOTES.md, and ``.agents/skills/``."""
     if clean:
@@ -266,14 +397,19 @@ def scaffold_codex(
         _read_template("codex", "config.toml"),
         overwrite=effective_overwrite,
     )
-    for skill_name in AGENTS_SKILL_DIRS:
+    active_skills = skills_for_config(repo_type, branch_strategy)
+    skills_dir = target_dir / ".agents" / "skills"
+    for skill_name in active_skills:
         _write_file(
-            target_dir / ".agents" / "skills" / skill_name / "SKILL.md",
+            skills_dir / skill_name / "SKILL.md",
             _read_template("agents", "skills", skill_name, "SKILL.md"),
             overwrite=effective_overwrite,
         )
 
-    _write_notes(target_dir)
+    if repo_type is not None:
+        _remove_stale_skills(skills_dir, active_skills)
+
+    _write_notes(target_dir, repo_type=repo_type)
     console.print("[bold green]Codex configuration ready.[/bold green]")
 
 
@@ -283,6 +419,7 @@ def scaffold_aider(
     overwrite: bool = False,
     clean: bool = False,
     merge: bool = False,
+    repo_type: RepoType | None = None,
 ) -> None:
     """Create ``.aider.conf.yml``, ``NOTES.md``, and ``.aiderignore``."""
     if clean:
@@ -300,5 +437,5 @@ def scaffold_aider(
         overwrite=effective_overwrite,
     )
 
-    _write_notes(target_dir)
+    _write_notes(target_dir, repo_type=repo_type)
     console.print("[bold green]Aider configuration ready.[/bold green]")

--- a/src/ai_shell/templates/agents/skills/ai-mono-foreach/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-foreach/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: ai-mono-foreach
+description: Run a command or skill in every submodule and aggregate results. Use when saying 'run across all repos' or 'in each submodule'.
+argument-hint: "<command or skill>"
+---
+
+Run a command in every submodule: $ARGUMENTS
+
+Iterates all submodules, runs the specified command or skill in each, and aggregates results.
+
+## Usage Examples
+- `/ai-mono-foreach git status` - Check git status in each submodule
+- `/ai-mono-foreach uv sync` - Install deps in each Python submodule
+- `/ai-mono-foreach /ai-standardize-repo --status` - Check standards in each submodule
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Parse Arguments
+
+The command to run is everything in `$ARGUMENTS`. It can be:
+- A shell command: `git status`, `uv sync`, `npm install`
+- A skill invocation: `/ai-standardize-repo --status`
+- Any executable command
+
+## 3. Iterate Submodules
+
+```bash
+SUBMODULES=$(git submodule status | awk '{print $2}')
+TOTAL=$(echo "$SUBMODULES" | wc -l)
+PASS=0
+FAIL=0
+SKIP=0
+
+for SUBMODULE in $SUBMODULES; do
+    echo ""
+    echo "=== $SUBMODULE ==="
+
+    if [ ! -d "$SUBMODULE" ]; then
+        echo "SKIP: Directory not found (submodule not initialized)"
+        SKIP=$((SKIP + 1))
+        continue
+    fi
+
+    cd "$SUBMODULE"
+
+    # Run the command
+    # If it's a skill invocation (starts with /), handle accordingly
+    # If it's a shell command, run it directly
+    eval "$ARGUMENTS"
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL (exit code: $EXIT_CODE)"
+        FAIL=$((FAIL + 1))
+    fi
+
+    cd ..
+done
+```
+
+## 4. Aggregate Results
+
+```
+Foreach Results
+===============
+
+Command: git status
+Submodules: 3 total
+
+  | Submodule | Result |
+  |-----------|--------|
+  | backend   | PASS   |
+  | frontend  | PASS   |
+  | infra     | FAIL   |
+
+Summary: 2 passed, 1 failed, 0 skipped
+```
+
+## 5. Handle Failures
+
+If any submodule failed:
+- List the failed submodules
+- Suggest investigating: "Check failed submodule: `cd infra && <command>`"
+- Do NOT stop on first failure -- always complete all submodules
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **No arguments**: Ask what command to run
+- **Submodule not initialized**: Skip with warning, count as skipped
+- **Command not found**: Fail that submodule, continue to next

--- a/src/ai_shell/templates/agents/skills/ai-mono-health/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-health/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: ai-mono-health
+description: Cross-repo health analysis covering dependency overlap, version alignment, and standards compliance. Use when asking 'check monorepo health' or 'cross-repo analysis'.
+argument-hint: "[--submodule <name>]"
+---
+
+Analyze cross-repo health across all submodules: $ARGUMENTS
+
+Checks dependency overlap, version alignment, submodule pointer freshness, and standards compliance across all submodules.
+
+## Usage Examples
+- `/ai-mono-health` - Full health analysis
+- `/ai-mono-health --submodule backend` - Health check for one submodule
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Resolve Tracked Branch Per Submodule
+
+Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+
+```bash
+tracked_branch_for() {
+    local sub="$1"
+    local branch
+    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    echo "main"
+}
+```
+
+## 3. Submodule Pointer Freshness
+
+For each submodule, check how far behind the pointer is from its tracked branch:
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    TRACKED=$(tracked_branch_for "$SUBMODULE")
+    POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
+    cd "$SUBMODULE"
+    git fetch --all --prune 2>/dev/null
+    REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
+    if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
+        BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
+        DAYS=$(git log -1 --format="%cr" "$POINTER_SHA")
+        echo "$SUBMODULE ($TRACKED): $BEHIND commits behind (pointer from $DAYS)"
+    else
+        echo "$SUBMODULE ($TRACKED): up to date"
+    fi
+    cd ..
+done
+```
+
+## 4. Branch Configuration Audit
+
+Check that each submodule has a tracked branch configured in `.gitmodules`:
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
+    if [ -z "$BRANCH" ]; then
+        echo "[WARN] $SUBMODULE: no branch set in .gitmodules (defaults to remote HEAD)"
+        echo "  Fix: git config -f .gitmodules submodule.${SUBMODULE}.branch <branch>"
+    else
+        echo "[OK] $SUBMODULE: tracks $BRANCH"
+    fi
+done
+```
+
+## 5. Dependency Overlap Analysis
+
+Scan each submodule for dependency files and find shared dependencies:
+
+```bash
+# Python repos: pyproject.toml, requirements.txt
+# Node repos: package.json
+# Terraform: versions.tf
+
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    if [ -f "$SUBMODULE/pyproject.toml" ]; then
+        echo "[$SUBMODULE] Python project"
+        # Extract dependencies
+    elif [ -f "$SUBMODULE/package.json" ]; then
+        echo "[$SUBMODULE] Node project"
+        # Extract dependencies
+    fi
+done
+```
+
+Cross-reference shared dependencies and flag version mismatches:
+- Same package at different versions across submodules
+- Outdated versions relative to latest available
+
+## 6. Standards Compliance
+
+For each submodule, check:
+- Pre-commit config exists and is consistent
+- CI workflows follow standard patterns
+- .editorconfig is present and consistent
+- .gitignore covers standard patterns
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    echo "--- $SUBMODULE ---"
+    [ -f "$SUBMODULE/.pre-commit-config.yaml" ] && echo "[OK] pre-commit" || echo "[MISSING] pre-commit"
+    [ -f "$SUBMODULE/.editorconfig" ] && echo "[OK] editorconfig" || echo "[MISSING] editorconfig"
+    [ -d "$SUBMODULE/.github/workflows" ] && echo "[OK] CI workflows" || echo "[MISSING] CI workflows"
+done
+```
+
+## 7. Health Report
+
+```
+Monorepo Health Report
+======================
+
+Pointer Freshness:
+  | Submodule  | Tracks | Status     | Behind | Last Updated |
+  |------------|--------|------------|--------|--------------|
+  | backend    | dev    | stale      | 5      | 3 days ago   |
+  | frontend   | dev    | up to date | 0      | today        |
+  | shared-lib | main   | up to date | 0      | today        |
+
+Branch Config:
+  | Submodule  | .gitmodules branch | Status |
+  |------------|--------------------|--------|
+  | backend    | dev                | OK     |
+  | frontend   | dev                | OK     |
+  | shared-lib | (not set)          | WARN   |
+
+Dependency Overlap:
+  | Package   | backend | frontend | Aligned? |
+  |-----------|---------|----------|----------|
+  | pydantic  | 2.9.0   | -        | n/a      |
+  | requests  | 2.32.0  | -        | n/a      |
+
+Standards Compliance:
+  | Check       | backend | frontend | infra |
+  |-------------|---------|----------|-------|
+  | pre-commit  | OK      | OK       | MISS  |
+  | editorconfig| OK      | OK       | OK    |
+  | CI          | OK      | OK       | OK    |
+
+Recommendations:
+  1. Update stale pointers: /ai-mono-sync
+  2. Set tracked branch for shared-lib: git config -f .gitmodules submodule.shared-lib.branch main
+  3. Add pre-commit to infra: cd infra && /ai-standardize-precommit
+```
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **Submodule not initialized**: Suggest `/ai-mono-init`
+- **No dependency files found**: Skip dependency analysis for that submodule

--- a/src/ai_shell/templates/agents/skills/ai-mono-init/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-init/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ai-mono-init
+description: First-time monorepo development setup. Initializes submodules and verifies environment. Use when setting up a monorepo for development or saying 'set up this monorepo'.
+argument-hint: ""
+---
+
+Set up this monorepo for development: $ARGUMENTS
+
+Initializes all submodules, verifies tracked branches are configured in `.gitmodules`, checks .env files, and guides the user through per-submodule AI tool setup.
+
+## Usage Examples
+- `/ai-mono-init` - Full first-time setup
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Initialize Submodules
+
+```bash
+git submodule update --init --recursive
+```
+
+Report which submodules were initialized.
+
+## 3. Verify Tracked Branches
+
+Each submodule should have a `branch` configured in `.gitmodules` so that `/ai-mono-sync` knows which branch to track. IaC repos with a dev-to-main workflow should track `dev`; library repos should track `main`.
+
+```bash
+NEEDS_BRANCH_CONFIG=()
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
+    if [ -z "$BRANCH" ]; then
+        NEEDS_BRANCH_CONFIG+=("$SUBMODULE")
+        echo "[WARN] $SUBMODULE: no branch set in .gitmodules"
+    else
+        echo "[OK] $SUBMODULE: tracks $BRANCH"
+    fi
+done
+```
+
+If any submodules are missing branch config, guide the user:
+
+```
+The following submodules have no tracked branch in .gitmodules:
+  - frontend
+  - shared-lib
+
+Set the branch each submodule should track:
+  - IaC repos (dev-to-main workflow): git config -f .gitmodules submodule.frontend.branch dev
+  - Library repos (main-only):        git config -f .gitmodules submodule.shared-lib.branch main
+
+Then commit the change:
+  git add .gitmodules && git commit -m "chore: set tracked branches for submodules"
+```
+
+Ask the user which branch each unconfigured submodule should track, then run the `git config -f .gitmodules` commands and commit.
+
+## 4. Verify Environment Files
+
+For each submodule, check for `.env`:
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    if [ -f "$SUBMODULE/.env" ]; then
+        echo "[OK] $SUBMODULE/.env exists"
+    elif [ -f "$SUBMODULE/.env.example" ]; then
+        echo "[WARN] $SUBMODULE/.env missing -- copy from .env.example:"
+        echo "  cp $SUBMODULE/.env.example $SUBMODULE/.env"
+    else
+        echo "[WARN] $SUBMODULE has no .env or .env.example"
+    fi
+done
+```
+
+Also check the monorepo root:
+```bash
+if [ -f ".env" ]; then
+    echo "[OK] Monorepo root .env exists"
+elif [ -f ".env.example" ]; then
+    echo "[WARN] Root .env missing -- copy from .env.example"
+else
+    echo "[INFO] No .env at monorepo root (may not be needed)"
+fi
+```
+
+## 5. Check Dev Dependencies
+
+If the monorepo root has a `pyproject.toml`:
+```bash
+if [ -f "pyproject.toml" ]; then
+    echo "Installing monorepo dev dependencies..."
+    uv sync
+fi
+```
+
+## 6. Report Setup Status
+
+```
+Monorepo setup complete!
+
+Submodules initialized:
+  - backend (tracks dev)
+  - frontend (tracks dev)
+  - shared-lib (tracks main)
+
+Environment:
+  - [OK] Root .env
+  - [OK] backend/.env
+  - [WARN] frontend/.env -- needs setup (see frontend/.env.example)
+
+Next steps:
+  1. Fix any .env warnings above
+  2. Set up AI tools in each submodule:
+     cd backend && ai-shell init --iac --all
+     cd frontend && ai-shell init --iac --all
+     cd shared-lib && ai-shell init --lib --all
+  3. Check monorepo status: /ai-mono-status
+```
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **Submodule clone fails**: Report which submodule failed, suggest checking SSH keys / access
+- **uv not available**: Skip dependency install, suggest installing uv

--- a/src/ai_shell/templates/agents/skills/ai-mono-status/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-status/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ai-mono-status
+description: Cross-repo status dashboard showing PRs, issues, pipelines, and submodule pointer state across all submodules. Use when asking 'what is happening across repos' or 'monorepo status'.
+argument-hint: "[--submodule <name>]"
+---
+
+Show cross-repo status across all submodules in this monorepo: $ARGUMENTS
+
+Provides a unified view of work happening across all submodules: open PRs, pipeline status, submodule pointer freshness, and suggested next actions.
+
+## Usage Examples
+- `/ai-mono-status` - Full status across all submodules
+- `/ai-mono-status --submodule backend` - Status for one submodule only
+
+## 1. Detect Submodules
+
+```bash
+# Verify this is a monorepo (has .gitmodules)
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    echo "Run this command from the monorepo root directory."
+    exit 1
+fi
+
+git submodule status --recursive
+```
+
+Parse each submodule: name, current SHA, path.
+
+## 2. Resolve Tracked Branch Per Submodule
+
+Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+
+```bash
+# Read the tracked branch from .gitmodules (falls back to remote HEAD, then "main")
+tracked_branch_for() {
+    local sub="$1"
+    # 1. Check .gitmodules branch setting
+    local branch
+    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    # 2. Fall back to the submodule's remote HEAD
+    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    # 3. Default to main
+    echo "main"
+}
+```
+
+## 3. Per-Submodule Status
+
+For each submodule:
+
+```bash
+SUBMODULE="backend"  # example
+TRACKED=$(tracked_branch_for "$SUBMODULE")
+
+# Current pointer vs tracked branch HEAD
+POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
+cd "$SUBMODULE"
+git fetch --all --prune 2>/dev/null
+
+REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
+
+# Commits behind
+if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
+    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" 2>/dev/null | wc -l)
+    echo "$SUBMODULE: $BEHIND commits behind origin/$TRACKED"
+else
+    echo "$SUBMODULE: up to date (tracking $TRACKED)"
+fi
+
+# Open PRs
+gh pr list --state open --json number,title,author,updatedAt --limit 5
+
+# Latest CI run
+gh run list --limit 1 --json status,conclusion,name,createdAt
+
+cd ..
+```
+
+## 4. Aggregated Dashboard
+
+Format output as a table:
+
+```
+Monorepo Status
+===============
+
+| Submodule | Tracks | Pointer  | Behind | Open PRs | CI Status |
+|-----------|--------|----------|--------|----------|-----------|
+| backend   | dev    | a1b2c3d  | 3      | 2        | passing   |
+| frontend  | dev    | d4e5f6g  | 0      | 1        | failing   |
+| shared-lib| main   | h7i8j9k  | 1      | 0        | passing   |
+
+Summary:
+  - 3 open PRs across all submodules
+  - 1 submodule with failing CI (frontend)
+  - 2 submodules with stale pointers
+```
+
+## 5. Suggested Next Actions
+
+Based on status, suggest:
+- If submodules are behind: "Run `/ai-mono-sync` to update pointers"
+- If CI is failing: "Check frontend: `cd frontend && /ai-monitor-pipeline`"
+- If PRs need review: List them with links
+- If a submodule has no `branch` set in `.gitmodules`: "Consider setting tracked branch: `git config -f .gitmodules submodule.backend.branch dev`"
+- If everything is clean: "All submodules are up to date. No action needed."
+
+## Error Handling
+- **Not a monorepo**: Clear error pointing to monorepo root
+- **Submodule not initialized**: Suggest `git submodule update --init`
+- **No GitHub remote**: Skip PR/CI checks for that submodule, warn
+- **Rate limiting**: Warn and show partial results

--- a/src/ai_shell/templates/agents/skills/ai-mono-sync/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-sync/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ai-mono-sync
+description: Sync submodule pointers to latest tracked branch HEAD. Use when saying 'update submodules', 'sync repos', or 'update pointers'.
+argument-hint: "[--commit] [--submodule <name>]"
+---
+
+Sync submodule pointers to their latest tracked branch HEAD: $ARGUMENTS
+
+Updates submodule pointers to the latest commit on each submodule's tracked branch (configured in `.gitmodules`), optionally staging and committing the pointer changes.
+
+## Usage Examples
+- `/ai-mono-sync` - Show what would change (dry run)
+- `/ai-mono-sync --commit` - Update pointers and commit changes
+- `/ai-mono-sync --submodule backend` - Sync only one submodule
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Resolve Tracked Branch Per Submodule
+
+Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+
+```bash
+tracked_branch_for() {
+    local sub="$1"
+    local branch
+    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    echo "main"
+}
+```
+
+## 3. Fetch All Submodules
+
+```bash
+git submodule update --init --recursive
+git submodule foreach git fetch --all --prune
+```
+
+## 4. Check Each Submodule
+
+For each submodule, compare the current pointer with the tracked branch HEAD:
+
+```bash
+SUBMODULE="backend"
+TRACKED=$(tracked_branch_for "$SUBMODULE")
+POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
+
+cd "$SUBMODULE"
+REMOTE_SHA=$(git rev-parse "origin/$TRACKED")
+
+if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
+    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
+    NEW_COMMITS=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" --limit 5)
+    echo "$SUBMODULE ($TRACKED): $BEHIND new commits"
+    echo "$NEW_COMMITS"
+fi
+cd ..
+```
+
+## 5. Show Changes Before Acting
+
+Display a summary of what would change:
+
+```
+Submodule pointer updates:
+  backend  (tracks dev):   a1b2c3d -> x9y8z7w  (3 commits)
+  frontend (tracks dev):   d4e5f6g -> d4e5f6g  (up to date)
+  shared-lib (tracks main): h7i8j9k -> m3n4o5p  (1 commit)
+```
+
+If `--commit` was NOT passed, stop here and ask: "Apply these changes? Run `/ai-mono-sync --commit` to update and commit."
+
+## 6. Update Pointers
+
+```bash
+# For each submodule that needs updating
+TRACKED=$(tracked_branch_for "$SUBMODULE")
+cd "$SUBMODULE"
+git checkout "$TRACKED"
+git pull origin "$TRACKED"
+cd ..
+```
+
+## 7. Stage and Commit
+
+```bash
+# Stage submodule pointer changes
+git add backend shared-lib  # only changed submodules
+
+# Build commit message listing what changed
+git commit -m "chore(deps): update submodule pointers
+
+- backend (dev): a1b2c3d -> x9y8z7w (3 commits)
+- shared-lib (main): h7i8j9k -> m3n4o5p (1 commit)"
+```
+
+## 8. Final Output
+
+```
+Submodule pointers updated and committed.
+
+Updated:
+  - backend (dev): 3 new commits
+  - shared-lib (main): 1 new commit
+Unchanged:
+  - frontend (dev)
+
+Commit: chore(deps): update submodule pointers
+Next: git push or /ai-submit-work
+```
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **Submodule has local changes**: Warn and skip that submodule
+- **Submodule in detached HEAD**: Re-attach to tracked branch before updating
+- **No changes**: Exit cleanly with "All submodules are up to date"
+- **No branch configured in .gitmodules**: Warn and fall back to remote HEAD or main

--- a/src/ai_shell/templates/ai-shell.toml
+++ b/src/ai_shell/templates/ai-shell.toml
@@ -2,6 +2,11 @@
 # Uncomment and modify the settings you want to override.
 # See: https://github.com/svange/augint-shell
 
+# [project]
+# repo_type = "library"           # "library" | "iac" | "monorepo"
+# branch_strategy = "main"        # "main" | "dev"
+# dev_branch = "dev"              # only when branch_strategy = "dev"
+
 # [container]
 # image = "svange/augint-shell"
 # image_tag = "latest"

--- a/src/ai_shell/templates/claude/skills/ai-mono-foreach/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-foreach/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: ai-mono-foreach
+description: Run a command or skill in every submodule and aggregate results. Use when saying 'run across all repos' or 'in each submodule'.
+argument-hint: "<command or skill>"
+---
+
+Run a command in every submodule: $ARGUMENTS
+
+Iterates all submodules, runs the specified command or skill in each, and aggregates results.
+
+## Usage Examples
+- `/ai-mono-foreach git status` - Check git status in each submodule
+- `/ai-mono-foreach uv sync` - Install deps in each Python submodule
+- `/ai-mono-foreach /ai-standardize-repo --status` - Check standards in each submodule
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Parse Arguments
+
+The command to run is everything in `$ARGUMENTS`. It can be:
+- A shell command: `git status`, `uv sync`, `npm install`
+- A skill invocation: `/ai-standardize-repo --status`
+- Any executable command
+
+## 3. Iterate Submodules
+
+```bash
+SUBMODULES=$(git submodule status | awk '{print $2}')
+TOTAL=$(echo "$SUBMODULES" | wc -l)
+PASS=0
+FAIL=0
+SKIP=0
+
+for SUBMODULE in $SUBMODULES; do
+    echo ""
+    echo "=== $SUBMODULE ==="
+
+    if [ ! -d "$SUBMODULE" ]; then
+        echo "SKIP: Directory not found (submodule not initialized)"
+        SKIP=$((SKIP + 1))
+        continue
+    fi
+
+    cd "$SUBMODULE"
+
+    # Run the command
+    # If it's a skill invocation (starts with /), handle accordingly
+    # If it's a shell command, run it directly
+    eval "$ARGUMENTS"
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL (exit code: $EXIT_CODE)"
+        FAIL=$((FAIL + 1))
+    fi
+
+    cd ..
+done
+```
+
+## 4. Aggregate Results
+
+```
+Foreach Results
+===============
+
+Command: git status
+Submodules: 3 total
+
+  | Submodule | Result |
+  |-----------|--------|
+  | backend   | PASS   |
+  | frontend  | PASS   |
+  | infra     | FAIL   |
+
+Summary: 2 passed, 1 failed, 0 skipped
+```
+
+## 5. Handle Failures
+
+If any submodule failed:
+- List the failed submodules
+- Suggest investigating: "Check failed submodule: `cd infra && <command>`"
+- Do NOT stop on first failure -- always complete all submodules
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **No arguments**: Ask what command to run
+- **Submodule not initialized**: Skip with warning, count as skipped
+- **Command not found**: Fail that submodule, continue to next

--- a/src/ai_shell/templates/claude/skills/ai-mono-health/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-health/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: ai-mono-health
+description: Cross-repo health analysis covering dependency overlap, version alignment, and standards compliance. Use when asking 'check monorepo health' or 'cross-repo analysis'.
+argument-hint: "[--submodule <name>]"
+---
+
+Analyze cross-repo health across all submodules: $ARGUMENTS
+
+Checks dependency overlap, version alignment, submodule pointer freshness, and standards compliance across all submodules.
+
+## Usage Examples
+- `/ai-mono-health` - Full health analysis
+- `/ai-mono-health --submodule backend` - Health check for one submodule
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Resolve Tracked Branch Per Submodule
+
+Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+
+```bash
+tracked_branch_for() {
+    local sub="$1"
+    local branch
+    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    echo "main"
+}
+```
+
+## 3. Submodule Pointer Freshness
+
+For each submodule, check how far behind the pointer is from its tracked branch:
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    TRACKED=$(tracked_branch_for "$SUBMODULE")
+    POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
+    cd "$SUBMODULE"
+    git fetch --all --prune 2>/dev/null
+    REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
+    if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
+        BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
+        DAYS=$(git log -1 --format="%cr" "$POINTER_SHA")
+        echo "$SUBMODULE ($TRACKED): $BEHIND commits behind (pointer from $DAYS)"
+    else
+        echo "$SUBMODULE ($TRACKED): up to date"
+    fi
+    cd ..
+done
+```
+
+## 4. Branch Configuration Audit
+
+Check that each submodule has a tracked branch configured in `.gitmodules`:
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
+    if [ -z "$BRANCH" ]; then
+        echo "[WARN] $SUBMODULE: no branch set in .gitmodules (defaults to remote HEAD)"
+        echo "  Fix: git config -f .gitmodules submodule.${SUBMODULE}.branch <branch>"
+    else
+        echo "[OK] $SUBMODULE: tracks $BRANCH"
+    fi
+done
+```
+
+## 5. Dependency Overlap Analysis
+
+Scan each submodule for dependency files and find shared dependencies:
+
+```bash
+# Python repos: pyproject.toml, requirements.txt
+# Node repos: package.json
+# Terraform: versions.tf
+
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    if [ -f "$SUBMODULE/pyproject.toml" ]; then
+        echo "[$SUBMODULE] Python project"
+        # Extract dependencies
+    elif [ -f "$SUBMODULE/package.json" ]; then
+        echo "[$SUBMODULE] Node project"
+        # Extract dependencies
+    fi
+done
+```
+
+Cross-reference shared dependencies and flag version mismatches:
+- Same package at different versions across submodules
+- Outdated versions relative to latest available
+
+## 6. Standards Compliance
+
+For each submodule, check:
+- Pre-commit config exists and is consistent
+- CI workflows follow standard patterns
+- .editorconfig is present and consistent
+- .gitignore covers standard patterns
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    echo "--- $SUBMODULE ---"
+    [ -f "$SUBMODULE/.pre-commit-config.yaml" ] && echo "[OK] pre-commit" || echo "[MISSING] pre-commit"
+    [ -f "$SUBMODULE/.editorconfig" ] && echo "[OK] editorconfig" || echo "[MISSING] editorconfig"
+    [ -d "$SUBMODULE/.github/workflows" ] && echo "[OK] CI workflows" || echo "[MISSING] CI workflows"
+done
+```
+
+## 7. Health Report
+
+```
+Monorepo Health Report
+======================
+
+Pointer Freshness:
+  | Submodule  | Tracks | Status     | Behind | Last Updated |
+  |------------|--------|------------|--------|--------------|
+  | backend    | dev    | stale      | 5      | 3 days ago   |
+  | frontend   | dev    | up to date | 0      | today        |
+  | shared-lib | main   | up to date | 0      | today        |
+
+Branch Config:
+  | Submodule  | .gitmodules branch | Status |
+  |------------|--------------------|--------|
+  | backend    | dev                | OK     |
+  | frontend   | dev                | OK     |
+  | shared-lib | (not set)          | WARN   |
+
+Dependency Overlap:
+  | Package   | backend | frontend | Aligned? |
+  |-----------|---------|----------|----------|
+  | pydantic  | 2.9.0   | -        | n/a      |
+  | requests  | 2.32.0  | -        | n/a      |
+
+Standards Compliance:
+  | Check       | backend | frontend | infra |
+  |-------------|---------|----------|-------|
+  | pre-commit  | OK      | OK       | MISS  |
+  | editorconfig| OK      | OK       | OK    |
+  | CI          | OK      | OK       | OK    |
+
+Recommendations:
+  1. Update stale pointers: /ai-mono-sync
+  2. Set tracked branch for shared-lib: git config -f .gitmodules submodule.shared-lib.branch main
+  3. Add pre-commit to infra: cd infra && /ai-standardize-precommit
+```
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **Submodule not initialized**: Suggest `/ai-mono-init`
+- **No dependency files found**: Skip dependency analysis for that submodule

--- a/src/ai_shell/templates/claude/skills/ai-mono-init/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-init/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ai-mono-init
+description: First-time monorepo development setup. Initializes submodules and verifies environment. Use when setting up a monorepo for development or saying 'set up this monorepo'.
+argument-hint: ""
+---
+
+Set up this monorepo for development: $ARGUMENTS
+
+Initializes all submodules, verifies tracked branches are configured in `.gitmodules`, checks .env files, and guides the user through per-submodule AI tool setup.
+
+## Usage Examples
+- `/ai-mono-init` - Full first-time setup
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Initialize Submodules
+
+```bash
+git submodule update --init --recursive
+```
+
+Report which submodules were initialized.
+
+## 3. Verify Tracked Branches
+
+Each submodule should have a `branch` configured in `.gitmodules` so that `/ai-mono-sync` knows which branch to track. IaC repos with a dev-to-main workflow should track `dev`; library repos should track `main`.
+
+```bash
+NEEDS_BRANCH_CONFIG=()
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
+    if [ -z "$BRANCH" ]; then
+        NEEDS_BRANCH_CONFIG+=("$SUBMODULE")
+        echo "[WARN] $SUBMODULE: no branch set in .gitmodules"
+    else
+        echo "[OK] $SUBMODULE: tracks $BRANCH"
+    fi
+done
+```
+
+If any submodules are missing branch config, guide the user:
+
+```
+The following submodules have no tracked branch in .gitmodules:
+  - frontend
+  - shared-lib
+
+Set the branch each submodule should track:
+  - IaC repos (dev-to-main workflow): git config -f .gitmodules submodule.frontend.branch dev
+  - Library repos (main-only):        git config -f .gitmodules submodule.shared-lib.branch main
+
+Then commit the change:
+  git add .gitmodules && git commit -m "chore: set tracked branches for submodules"
+```
+
+Ask the user which branch each unconfigured submodule should track, then run the `git config -f .gitmodules` commands and commit.
+
+## 4. Verify Environment Files
+
+For each submodule, check for `.env`:
+
+```bash
+for SUBMODULE in $(git submodule status | awk '{print $2}'); do
+    if [ -f "$SUBMODULE/.env" ]; then
+        echo "[OK] $SUBMODULE/.env exists"
+    elif [ -f "$SUBMODULE/.env.example" ]; then
+        echo "[WARN] $SUBMODULE/.env missing -- copy from .env.example:"
+        echo "  cp $SUBMODULE/.env.example $SUBMODULE/.env"
+    else
+        echo "[WARN] $SUBMODULE has no .env or .env.example"
+    fi
+done
+```
+
+Also check the monorepo root:
+```bash
+if [ -f ".env" ]; then
+    echo "[OK] Monorepo root .env exists"
+elif [ -f ".env.example" ]; then
+    echo "[WARN] Root .env missing -- copy from .env.example"
+else
+    echo "[INFO] No .env at monorepo root (may not be needed)"
+fi
+```
+
+## 5. Check Dev Dependencies
+
+If the monorepo root has a `pyproject.toml`:
+```bash
+if [ -f "pyproject.toml" ]; then
+    echo "Installing monorepo dev dependencies..."
+    uv sync
+fi
+```
+
+## 6. Report Setup Status
+
+```
+Monorepo setup complete!
+
+Submodules initialized:
+  - backend (tracks dev)
+  - frontend (tracks dev)
+  - shared-lib (tracks main)
+
+Environment:
+  - [OK] Root .env
+  - [OK] backend/.env
+  - [WARN] frontend/.env -- needs setup (see frontend/.env.example)
+
+Next steps:
+  1. Fix any .env warnings above
+  2. Set up AI tools in each submodule:
+     cd backend && ai-shell init --iac --all
+     cd frontend && ai-shell init --iac --all
+     cd shared-lib && ai-shell init --lib --all
+  3. Check monorepo status: /ai-mono-status
+```
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **Submodule clone fails**: Report which submodule failed, suggest checking SSH keys / access
+- **uv not available**: Skip dependency install, suggest installing uv

--- a/src/ai_shell/templates/claude/skills/ai-mono-status/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-status/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ai-mono-status
+description: Cross-repo status dashboard showing PRs, issues, pipelines, and submodule pointer state across all submodules. Use when asking 'what is happening across repos' or 'monorepo status'.
+argument-hint: "[--submodule <name>]"
+---
+
+Show cross-repo status across all submodules in this monorepo: $ARGUMENTS
+
+Provides a unified view of work happening across all submodules: open PRs, pipeline status, submodule pointer freshness, and suggested next actions.
+
+## Usage Examples
+- `/ai-mono-status` - Full status across all submodules
+- `/ai-mono-status --submodule backend` - Status for one submodule only
+
+## 1. Detect Submodules
+
+```bash
+# Verify this is a monorepo (has .gitmodules)
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    echo "Run this command from the monorepo root directory."
+    exit 1
+fi
+
+git submodule status --recursive
+```
+
+Parse each submodule: name, current SHA, path.
+
+## 2. Resolve Tracked Branch Per Submodule
+
+Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+
+```bash
+# Read the tracked branch from .gitmodules (falls back to remote HEAD, then "main")
+tracked_branch_for() {
+    local sub="$1"
+    # 1. Check .gitmodules branch setting
+    local branch
+    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    # 2. Fall back to the submodule's remote HEAD
+    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    # 3. Default to main
+    echo "main"
+}
+```
+
+## 3. Per-Submodule Status
+
+For each submodule:
+
+```bash
+SUBMODULE="backend"  # example
+TRACKED=$(tracked_branch_for "$SUBMODULE")
+
+# Current pointer vs tracked branch HEAD
+POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
+cd "$SUBMODULE"
+git fetch --all --prune 2>/dev/null
+
+REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
+
+# Commits behind
+if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
+    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" 2>/dev/null | wc -l)
+    echo "$SUBMODULE: $BEHIND commits behind origin/$TRACKED"
+else
+    echo "$SUBMODULE: up to date (tracking $TRACKED)"
+fi
+
+# Open PRs
+gh pr list --state open --json number,title,author,updatedAt --limit 5
+
+# Latest CI run
+gh run list --limit 1 --json status,conclusion,name,createdAt
+
+cd ..
+```
+
+## 4. Aggregated Dashboard
+
+Format output as a table:
+
+```
+Monorepo Status
+===============
+
+| Submodule | Tracks | Pointer  | Behind | Open PRs | CI Status |
+|-----------|--------|----------|--------|----------|-----------|
+| backend   | dev    | a1b2c3d  | 3      | 2        | passing   |
+| frontend  | dev    | d4e5f6g  | 0      | 1        | failing   |
+| shared-lib| main   | h7i8j9k  | 1      | 0        | passing   |
+
+Summary:
+  - 3 open PRs across all submodules
+  - 1 submodule with failing CI (frontend)
+  - 2 submodules with stale pointers
+```
+
+## 5. Suggested Next Actions
+
+Based on status, suggest:
+- If submodules are behind: "Run `/ai-mono-sync` to update pointers"
+- If CI is failing: "Check frontend: `cd frontend && /ai-monitor-pipeline`"
+- If PRs need review: List them with links
+- If a submodule has no `branch` set in `.gitmodules`: "Consider setting tracked branch: `git config -f .gitmodules submodule.backend.branch dev`"
+- If everything is clean: "All submodules are up to date. No action needed."
+
+## Error Handling
+- **Not a monorepo**: Clear error pointing to monorepo root
+- **Submodule not initialized**: Suggest `git submodule update --init`
+- **No GitHub remote**: Skip PR/CI checks for that submodule, warn
+- **Rate limiting**: Warn and show partial results

--- a/src/ai_shell/templates/claude/skills/ai-mono-sync/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-sync/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ai-mono-sync
+description: Sync submodule pointers to latest tracked branch HEAD. Use when saying 'update submodules', 'sync repos', or 'update pointers'.
+argument-hint: "[--commit] [--submodule <name>]"
+---
+
+Sync submodule pointers to their latest tracked branch HEAD: $ARGUMENTS
+
+Updates submodule pointers to the latest commit on each submodule's tracked branch (configured in `.gitmodules`), optionally staging and committing the pointer changes.
+
+## Usage Examples
+- `/ai-mono-sync` - Show what would change (dry run)
+- `/ai-mono-sync --commit` - Update pointers and commit changes
+- `/ai-mono-sync --submodule backend` - Sync only one submodule
+
+## 1. Verify Monorepo
+
+```bash
+if [ ! -f .gitmodules ]; then
+    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
+    exit 1
+fi
+```
+
+## 2. Resolve Tracked Branch Per Submodule
+
+Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+
+```bash
+tracked_branch_for() {
+    local sub="$1"
+    local branch
+    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [ -n "$branch" ]; then
+        echo "$branch"
+        return
+    fi
+    echo "main"
+}
+```
+
+## 3. Fetch All Submodules
+
+```bash
+git submodule update --init --recursive
+git submodule foreach git fetch --all --prune
+```
+
+## 4. Check Each Submodule
+
+For each submodule, compare the current pointer with the tracked branch HEAD:
+
+```bash
+SUBMODULE="backend"
+TRACKED=$(tracked_branch_for "$SUBMODULE")
+POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
+
+cd "$SUBMODULE"
+REMOTE_SHA=$(git rev-parse "origin/$TRACKED")
+
+if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
+    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
+    NEW_COMMITS=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" --limit 5)
+    echo "$SUBMODULE ($TRACKED): $BEHIND new commits"
+    echo "$NEW_COMMITS"
+fi
+cd ..
+```
+
+## 5. Show Changes Before Acting
+
+Display a summary of what would change:
+
+```
+Submodule pointer updates:
+  backend  (tracks dev):   a1b2c3d -> x9y8z7w  (3 commits)
+  frontend (tracks dev):   d4e5f6g -> d4e5f6g  (up to date)
+  shared-lib (tracks main): h7i8j9k -> m3n4o5p  (1 commit)
+```
+
+If `--commit` was NOT passed, stop here and ask: "Apply these changes? Run `/ai-mono-sync --commit` to update and commit."
+
+## 6. Update Pointers
+
+```bash
+# For each submodule that needs updating
+TRACKED=$(tracked_branch_for "$SUBMODULE")
+cd "$SUBMODULE"
+git checkout "$TRACKED"
+git pull origin "$TRACKED"
+cd ..
+```
+
+## 7. Stage and Commit
+
+```bash
+# Stage submodule pointer changes
+git add backend shared-lib  # only changed submodules
+
+# Build commit message listing what changed
+git commit -m "chore(deps): update submodule pointers
+
+- backend (dev): a1b2c3d -> x9y8z7w (3 commits)
+- shared-lib (main): h7i8j9k -> m3n4o5p (1 commit)"
+```
+
+## 8. Final Output
+
+```
+Submodule pointers updated and committed.
+
+Updated:
+  - backend (dev): 3 new commits
+  - shared-lib (main): 1 new commit
+Unchanged:
+  - frontend (dev)
+
+Commit: chore(deps): update submodule pointers
+Next: git push or /ai-submit-work
+```
+
+## Error Handling
+- **Not a monorepo**: Clear error
+- **Submodule has local changes**: Warn and skip that submodule
+- **Submodule in detached HEAD**: Re-attach to tracked branch before updating
+- **No changes**: Exit cleanly with "All submodules are up to date"
+- **No branch configured in .gitmodules**: Warn and fall back to remote HEAD or main

--- a/src/ai_shell/templates/notes-iac.md
+++ b/src/ai_shell/templates/notes-iac.md
@@ -1,0 +1,89 @@
+# Project Notes
+
+<!-- Project-specific notes for AI coding agents. This file is created
+     once by ai-shell and NEVER overwritten or deleted by scaffold
+     operations (--update, --clean). Each agent's /init reads this file
+     and integrates it into the appropriate config (CLAUDE.md, AGENTS.md,
+     CONVENTIONS.md). -->
+
+## Project Overview
+
+<!-- Describe your project here. This file is read automatically by Codex and opencode. -->
+
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No manual versioning**: NEVER manually edit version numbers. Semantic Release manages versions via conventional commits.
+- **No lock file edits**: NEVER directly write text into lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock). Always use package manager commands (`uv lock`, `uv add`, `npm install`) to regenerate them. When a package manager command updates a lock file, ALWAYS stage and include it in the commit -- lock file changes must never be left uncommitted.
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+
+## Development Commands
+
+```bash
+uv sync --all-extras                         # Install dependencies
+uv run pytest                                # Run tests
+uv run pytest --cov=src --cov-fail-under=80  # Tests with coverage
+uv run ruff check src/                       # Lint
+uv run mypy src/                             # Type check
+uv run pre-commit run --all-files            # Run all pre-commit hooks
+```
+
+## Conventions
+
+- **Commits**: Conventional commits required. `fix:` = patch, `feat:` = minor, `feat!:` / `BREAKING CHANGE` = major.
+- **Branches**: `{type}/issue-N-description` where type is one of: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf.
+- **PRs**: Target the default development branch. Enable automerge.
+- **Pre-commit**: Run `uv run pre-commit run --all-files` explicitly before committing (no automatic git hooks -- they break across Windows/WSL). If checks fail, fix the issue and create a NEW commit (do not amend).
+- **Tests**: Write tests for all new functionality. Bug fixes require regression tests.
+
+## Development Workflow
+
+**IMPORTANT**: Always follow this sequence. Do NOT skip to step 3 without completing step 2 first.
+
+1. **Pick an issue**: `/ai-pick-issue` -- find or get assigned work
+2. **Prepare branch**: `/ai-prepare-branch` -- REQUIRED before any code changes. Creates a fresh branch from the latest base (main or dev), syncs upstream, sets up remote tracking. Never start coding on an existing branch from a previous task.
+3. **Develop**: Write code with tests, following project conventions
+4. **Submit**: `/ai-submit-work` -- runs all checks locally, commits, pushes, creates automerge PR
+5. **Monitor**: `/ai-monitor-pipeline` -- watches CI, diagnoses failures, auto-fixes and re-pushes
+6. **Promote** (dev-based repos): `/ai-promote` -- promotes dev to main when staging is ready for release
+
+## Deployment
+
+<!-- This is an IaC / web / backend repo. Describe your deployment pipeline:
+     - Environments (dev, staging, production)
+     - Deployment triggers (merge to main, manual, etc.)
+     - OIDC / IAM / auth requirements
+     - Infrastructure dependencies -->
+
+## Key Commands
+
+```bash
+# Git
+git status                    # Check working tree
+git log --oneline -10         # Recent commits
+
+# GitHub CLI
+gh issue list --state open    # View open issues
+gh pr create                  # Create pull request
+gh pr merge --auto --squash   # Enable automerge
+gh run list                   # List workflow runs
+gh run view <id>              # View run details
+gh run watch <id>             # Watch run in real-time
+```
+
+## Architecture
+
+<!-- Key architectural decisions, dependency flow, module structure -->
+
+## Domain Concepts
+
+<!-- Important domain terms, business rules, or constraints -->
+
+## Project-Specific Commands
+
+<!-- Any project-specific commands beyond the defaults above -->
+
+## Notes
+
+<!-- Anything else an AI agent should know about this project -->

--- a/src/ai_shell/templates/notes-library.md
+++ b/src/ai_shell/templates/notes-library.md
@@ -1,0 +1,87 @@
+# Project Notes
+
+<!-- Project-specific notes for AI coding agents. This file is created
+     once by ai-shell and NEVER overwritten or deleted by scaffold
+     operations (--update, --clean). Each agent's /init reads this file
+     and integrates it into the appropriate config (CLAUDE.md, AGENTS.md,
+     CONVENTIONS.md). -->
+
+## Project Overview
+
+<!-- Describe your project here. This file is read automatically by Codex and opencode. -->
+
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No manual versioning**: NEVER manually edit version numbers. Semantic Release manages versions via conventional commits.
+- **No lock file edits**: NEVER directly write text into lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock). Always use package manager commands (`uv lock`, `uv add`, `npm install`) to regenerate them. When a package manager command updates a lock file, ALWAYS stage and include it in the commit -- lock file changes must never be left uncommitted.
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+
+## Development Commands
+
+```bash
+uv sync --all-extras                         # Install dependencies
+uv run pytest                                # Run tests
+uv run pytest --cov=src --cov-fail-under=80  # Tests with coverage
+uv run ruff check src/                       # Lint
+uv run mypy src/                             # Type check
+uv run pre-commit run --all-files            # Run all pre-commit hooks
+```
+
+## Conventions
+
+- **Commits**: Conventional commits required. `fix:` = patch, `feat:` = minor, `feat!:` / `BREAKING CHANGE` = major.
+- **Branches**: `{type}/issue-N-description` where type is one of: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf.
+- **PRs**: Target main. Enable automerge.
+- **Pre-commit**: Run `uv run pre-commit run --all-files` explicitly before committing (no automatic git hooks -- they break across Windows/WSL). If checks fail, fix the issue and create a NEW commit (do not amend).
+- **Tests**: Write tests for all new functionality. Bug fixes require regression tests.
+
+## Development Workflow
+
+**IMPORTANT**: Always follow this sequence. Do NOT skip to step 3 without completing step 2 first.
+
+1. **Pick an issue**: `/ai-pick-issue` -- find or get assigned work
+2. **Prepare branch**: `/ai-prepare-branch` -- REQUIRED before any code changes. Creates a fresh branch from main, syncs upstream, sets up remote tracking. Never start coding on an existing branch from a previous task.
+3. **Develop**: Write code with tests, following project conventions
+4. **Submit**: `/ai-submit-work` -- runs all checks locally, commits, pushes, creates automerge PR to main
+5. **Monitor**: `/ai-monitor-pipeline` -- watches CI, diagnoses failures, auto-fixes and re-pushes
+
+## Publishing
+
+<!-- This is a library repo. Releases are triggered by merging to main:
+     - Semantic Release determines version from conventional commits
+     - Artifacts are built and published (PyPI, npm, etc.)
+     - No manual version bumps or tag creation needed -->
+
+## Key Commands
+
+```bash
+# Git
+git status                    # Check working tree
+git log --oneline -10         # Recent commits
+
+# GitHub CLI
+gh issue list --state open    # View open issues
+gh pr create                  # Create pull request
+gh pr merge --auto --squash   # Enable automerge
+gh run list                   # List workflow runs
+gh run view <id>              # View run details
+gh run watch <id>             # Watch run in real-time
+```
+
+## Architecture
+
+<!-- Key architectural decisions, dependency flow, module structure -->
+
+## Domain Concepts
+
+<!-- Important domain terms, business rules, or constraints -->
+
+## Project-Specific Commands
+
+<!-- Any project-specific commands beyond the defaults above -->
+
+## Notes
+
+<!-- Anything else an AI agent should know about this project -->

--- a/src/ai_shell/templates/notes-monorepo.md
+++ b/src/ai_shell/templates/notes-monorepo.md
@@ -1,0 +1,102 @@
+# Project Notes
+
+<!-- Project-specific notes for AI coding agents. This file is created
+     once by ai-shell and NEVER overwritten or deleted by scaffold
+     operations (--update, --clean). Each agent's /init reads this file
+     and integrates it into the appropriate config (CLAUDE.md, AGENTS.md,
+     CONVENTIONS.md). -->
+
+## Monorepo Overview
+
+<!-- Describe what this monorepo coordinates and the overall system architecture. -->
+
+## Submodule Map
+
+<!-- List each submodule, its purpose, tracked branch, and repo URL.
+
+| Submodule  | Purpose    | Tracks | Stack          | Repo                          |
+|------------|------------|--------|----------------|-------------------------------|
+| backend    | API server | dev    | Python/FastAPI | github.com/org/backend        |
+| frontend   | Web UI     | dev    | TypeScript/React | github.com/org/frontend     |
+| shared-lib | Shared utils | main | Python         | github.com/org/shared-lib     |
+
+Tracked branches are configured in `.gitmodules`. IaC repos with a dev-to-main
+workflow should track `dev`; library repos should track `main`. Set with:
+  git config -f .gitmodules submodule.<name>.branch <branch>
+-->
+
+## Critical Rules
+
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
+- **No .env commits**: NEVER commit .env files. Use .env.example for templates.
+- **No force push to main**: NEVER use `git push --force` on main or the default branch.
+- **No cross-boundary edits**: NEVER modify files inside submodules from the monorepo root. Always `cd` into the submodule to make changes using that submodule's own tooling and context.
+- **Commit pointer changes deliberately**: Submodule pointer updates should be intentional, never accidental side effects of other work.
+
+## Working in This Monorepo
+
+### When to work at monorepo level (this directory)
+- Cross-repo status and coordination: `/ai-mono-status`
+- Syncing submodule pointers: `/ai-mono-sync`
+- Cross-repo health analysis: `/ai-mono-health`
+- Editing monorepo-level docs, tools, and configs
+- Managing submodule relationships
+
+### When to work inside a submodule
+- All code development, bug fixes, and feature work
+- Running tests, linting, and type checking
+- Creating PRs and monitoring pipelines
+- Each submodule has its own `.env`, `ai-shell.toml`, and AI tool configs
+
+### Switching context
+```bash
+cd backend/                  # Enter submodule for development work
+ai-shell claude              # Launches with backend's .env and context
+cd ..                        # Return to monorepo root for coordination
+```
+
+## Environment Setup
+
+Each directory level has its own `.env` file:
+- **Monorepo root `.env`**: GH_TOKEN for cross-repo operations, shared service tokens
+- **Submodule `.env`**: Deployment credentials, environment-specific variables
+
+These are independent -- ai-shell loads `.env` from the current working directory only.
+
+## Monorepo Coordination Tools
+
+This monorepo uses `augint-mono` for coordination across submodules:
+
+```bash
+uv run augint-mono status    # Cross-repo status dashboard
+uv run augint-mono sync      # Update submodule pointers
+uv run augint-mono init      # First-time dev setup
+uv run augint-mono health    # Cross-repo health analysis
+uv run augint-mono foreach   # Run command in each submodule
+```
+
+## Conventions
+
+- **Commits**: Conventional commits required. `fix:` = patch, `feat:` = minor, `feat!:` / `BREAKING CHANGE` = major.
+- **Branches**: `{type}/issue-N-description` where type is one of: feat, fix, docs, refactor, test, chore, ci, build, style, revert, perf.
+- **Submodule updates**: Use `chore(deps):` prefix for submodule pointer update commits.
+
+## Development Workflow
+
+1. **Check status**: `/ai-mono-status` -- see what is happening across all repos
+2. **Sync pointers**: `/ai-mono-sync` -- ensure submodule pointers are current
+3. **Pick work**: Identify which submodule needs attention, `cd` into it
+4. **Develop**: Follow that submodule's own workflow (pick issue, prepare branch, develop, submit)
+5. **Update pointers**: Return to monorepo root, `/ai-mono-sync` to capture new commits
+
+## Architecture
+
+<!-- High-level system architecture showing how submodules relate to each other -->
+
+## Cross-Repo Conventions
+
+<!-- Shared dependency version policy, API contract locations, inter-service communication patterns -->
+
+## Notes
+
+<!-- Anything else an AI agent should know about this monorepo -->

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -193,7 +193,12 @@ class TestToolCommands:
                 result = self.runner.invoke(cli, ["opencode", "--init"])
 
         mock_scaffold.assert_called_once_with(
-            "/tmp/test", overwrite=False, clean=False, merge=False
+            "/tmp/test",
+            overwrite=False,
+            clean=False,
+            merge=False,
+            repo_type=None,
+            branch_strategy=None,
         )
         mock_manager_cls.assert_not_called()
         assert result.exit_code == 0
@@ -209,7 +214,14 @@ class TestToolCommands:
             ):
                 result = self.runner.invoke(cli, ["opencode", "--update"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=False, clean=False, merge=True)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=False,
+            clean=False,
+            merge=True,
+            repo_type=None,
+            branch_strategy=None,
+        )
         assert result.exit_code == 0
 
     def test_opencode_reset_calls_scaffold_with_overwrite(
@@ -223,7 +235,14 @@ class TestToolCommands:
             ):
                 result = self.runner.invoke(cli, ["opencode", "--reset"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=True, clean=False, merge=False)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=True,
+            clean=False,
+            merge=False,
+            repo_type=None,
+            branch_strategy=None,
+        )
         assert result.exit_code == 0
 
     def test_opencode_clean_calls_scaffold_with_clean(
@@ -234,7 +253,14 @@ class TestToolCommands:
             with patch("ai_shell.scaffold.scaffold_opencode") as mock_scaffold:
                 result = self.runner.invoke(cli, ["opencode", "--clean"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=True, clean=True, merge=False)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=True,
+            clean=True,
+            merge=False,
+            repo_type=None,
+            branch_strategy=None,
+        )
         mock_manager_cls.assert_not_called()
         assert result.exit_code == 0
 
@@ -245,7 +271,12 @@ class TestToolCommands:
                 result = self.runner.invoke(cli, ["codex", "--init"])
 
         mock_scaffold.assert_called_once_with(
-            "/tmp/test", overwrite=False, clean=False, merge=False
+            "/tmp/test",
+            overwrite=False,
+            clean=False,
+            merge=False,
+            repo_type=None,
+            branch_strategy=None,
         )
         mock_manager_cls.assert_not_called()
         assert result.exit_code == 0
@@ -261,7 +292,14 @@ class TestToolCommands:
             ):
                 result = self.runner.invoke(cli, ["codex", "--update"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=False, clean=False, merge=True)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=False,
+            clean=False,
+            merge=True,
+            repo_type=None,
+            branch_strategy=None,
+        )
         assert result.exit_code == 0
 
     def test_codex_reset_calls_scaffold_with_overwrite(
@@ -275,7 +313,14 @@ class TestToolCommands:
             ):
                 result = self.runner.invoke(cli, ["codex", "--reset"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=True, clean=False, merge=False)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=True,
+            clean=False,
+            merge=False,
+            repo_type=None,
+            branch_strategy=None,
+        )
         assert result.exit_code == 0
 
     def test_codex_clean_calls_scaffold_with_clean(
@@ -286,7 +331,14 @@ class TestToolCommands:
             with patch("ai_shell.scaffold.scaffold_codex") as mock_scaffold:
                 result = self.runner.invoke(cli, ["codex", "--clean"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=True, clean=True, merge=False)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=True,
+            clean=True,
+            merge=False,
+            repo_type=None,
+            branch_strategy=None,
+        )
         mock_manager_cls.assert_not_called()
         assert result.exit_code == 0
 
@@ -297,7 +349,11 @@ class TestToolCommands:
                 result = self.runner.invoke(cli, ["aider", "--init"])
 
         mock_scaffold.assert_called_once_with(
-            "/tmp/test", overwrite=False, clean=False, merge=False
+            "/tmp/test",
+            overwrite=False,
+            clean=False,
+            merge=False,
+            repo_type=None,
         )
         mock_manager_cls.assert_not_called()
         assert result.exit_code == 0
@@ -310,7 +366,13 @@ class TestToolCommands:
             with patch("ai_shell.scaffold.scaffold_aider") as mock_scaffold:
                 result = self.runner.invoke(cli, ["aider", "--update"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=False, clean=False, merge=True)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=False,
+            clean=False,
+            merge=True,
+            repo_type=None,
+        )
         assert result.exit_code == 0
 
     def test_aider_reset_calls_scaffold_with_overwrite(
@@ -321,7 +383,13 @@ class TestToolCommands:
             with patch("ai_shell.scaffold.scaffold_aider") as mock_scaffold:
                 result = self.runner.invoke(cli, ["aider", "--reset"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=True, clean=False, merge=False)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=True,
+            clean=False,
+            merge=False,
+            repo_type=None,
+        )
         assert result.exit_code == 0
 
     def test_aider_clean_calls_scaffold_with_clean(
@@ -332,7 +400,13 @@ class TestToolCommands:
             with patch("ai_shell.scaffold.scaffold_aider") as mock_scaffold:
                 result = self.runner.invoke(cli, ["aider", "--clean"])
 
-        mock_scaffold.assert_called_once_with("/tmp/test", overwrite=True, clean=True, merge=False)
+        mock_scaffold.assert_called_once_with(
+            "/tmp/test",
+            overwrite=True,
+            clean=True,
+            merge=False,
+            repo_type=None,
+        )
         mock_manager_cls.assert_not_called()
         assert result.exit_code == 0
 
@@ -340,12 +414,11 @@ class TestToolCommands:
         with patch("ai_shell.cli.commands.tools.Path") as mock_path:
             mock_path.cwd.return_value = "/tmp/test"
             with (
-                patch("ai_shell.scaffold.scaffold_claude") as mock_scaffold,
+                patch("ai_shell.scaffold.scaffold_claude"),
                 patch("ai_shell.notes_merge.merge_notes_into_context") as mock_merge,
             ):
                 result = self.runner.invoke(cli, ["claude", "--update"])
 
-        mock_scaffold.assert_called_once()
         mock_merge.assert_called_once_with("/tmp/test", "claude", background=True)
         assert result.exit_code == 0
 
@@ -450,7 +523,10 @@ class TestToolCommands:
                 patch("ai_shell.scaffold.scaffold_aider"),
                 patch("ai_shell.notes_merge.merge_notes_into_context") as mock_merge,
             ):
-                result = self.runner.invoke(cli, ["init", "--update", "--all", "--no-merge"])
+                result = self.runner.invoke(
+                    cli,
+                    ["init", "--update", "--all", "--no-merge", "--lib"],
+                )
 
         mock_merge.assert_not_called()
         assert result.exit_code == 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -168,3 +168,44 @@ ports = [9000, 9229]
         config = load_config(project_dir=tmp_path)
         # Should load defaults without error
         assert config.image == "svange/augint-shell"
+
+    def test_project_section_repo_type(self, tmp_path):
+        toml_content = b"""
+[project]
+repo_type = "library"
+branch_strategy = "main"
+"""
+        (tmp_path / "ai-shell.toml").write_bytes(toml_content)
+        config = load_config(project_dir=tmp_path)
+        assert config.repo_type == "library"
+        assert config.branch_strategy == "main"
+
+    def test_project_section_iac_dev(self, tmp_path):
+        toml_content = b"""
+[project]
+repo_type = "iac"
+branch_strategy = "dev"
+dev_branch = "staging"
+"""
+        (tmp_path / "ai-shell.toml").write_bytes(toml_content)
+        config = load_config(project_dir=tmp_path)
+        assert config.repo_type == "iac"
+        assert config.branch_strategy == "dev"
+        assert config.dev_branch == "staging"
+
+    def test_project_section_defaults(self, tmp_path):
+        config = load_config(project_dir=tmp_path)
+        assert config.repo_type is None
+        assert config.branch_strategy is None
+        assert config.dev_branch == "dev"
+
+    def test_project_section_monorepo(self, tmp_path):
+        toml_content = b"""
+[project]
+repo_type = "monorepo"
+branch_strategy = "main"
+"""
+        (tmp_path / "ai-shell.toml").write_bytes(toml_content)
+        config = load_config(project_dir=tmp_path)
+        assert config.repo_type == "monorepo"
+        assert config.branch_strategy == "main"

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -7,12 +7,15 @@ import yaml
 from ai_shell.scaffold import (
     AGENTS_SKILL_DIRS,
     CLAUDE_SKILL_DIRS,
+    BranchStrategy,
+    RepoType,
     _deep_merge_settings,
     scaffold_aider,
     scaffold_claude,
     scaffold_codex,
     scaffold_opencode,
     scaffold_project,
+    skills_for_config,
 )
 
 
@@ -584,3 +587,222 @@ class TestNotesFile:
         notes.write_text("Custom notes")
         scaffold_opencode(tmp_path)
         assert notes.read_text() == "Custom notes"
+
+
+class TestSkillsForConfig:
+    def test_none_returns_all_skills(self):
+        skills = skills_for_config(None, None)
+        assert skills == CLAUDE_SKILL_DIRS
+
+    def test_library_main_excludes_promote(self):
+        skills = skills_for_config(RepoType.LIBRARY, BranchStrategy.MAIN)
+        assert "ai-promote" not in skills
+        assert "ai-standardize-renovate" in skills
+        assert "ai-standardize-release" in skills
+        assert "ai-setup-oidc" not in skills
+
+    def test_library_dev_includes_promote(self):
+        skills = skills_for_config(RepoType.LIBRARY, BranchStrategy.DEV)
+        assert "ai-promote" in skills
+
+    def test_iac_main_has_oidc_no_promote(self):
+        skills = skills_for_config(RepoType.IAC, BranchStrategy.MAIN)
+        assert "ai-setup-oidc" in skills
+        assert "ai-promote" not in skills
+        assert "ai-standardize-renovate" in skills
+
+    def test_iac_dev_has_oidc_and_promote(self):
+        skills = skills_for_config(RepoType.IAC, BranchStrategy.DEV)
+        assert "ai-setup-oidc" in skills
+        assert "ai-promote" in skills
+
+    def test_monorepo_has_mono_skills(self):
+        skills = skills_for_config(RepoType.MONOREPO, BranchStrategy.MAIN)
+        assert "ai-mono-status" in skills
+        assert "ai-mono-sync" in skills
+        assert "ai-mono-init" in skills
+        assert "ai-mono-health" in skills
+        assert "ai-mono-foreach" in skills
+
+    def test_monorepo_excludes_release_renovate_oidc(self):
+        skills = skills_for_config(RepoType.MONOREPO, BranchStrategy.MAIN)
+        assert "ai-standardize-renovate" not in skills
+        assert "ai-standardize-release" not in skills
+        assert "ai-setup-oidc" not in skills
+        assert "ai-promote" not in skills
+
+    def test_monorepo_has_universal_skills(self):
+        skills = skills_for_config(RepoType.MONOREPO, BranchStrategy.MAIN)
+        assert "ai-pick-issue" in skills
+        assert "ai-prepare-branch" in skills
+        assert "ai-submit-work" in skills
+        assert "ai-status" in skills
+
+    def test_all_types_have_universal_skills(self):
+        for repo_type in RepoType:
+            skills = skills_for_config(repo_type, BranchStrategy.MAIN)
+            assert "ai-pick-issue" in skills
+            assert "ai-prepare-branch" in skills
+            assert "ai-submit-work" in skills
+            assert "ai-monitor-pipeline" in skills
+            assert "ai-status" in skills
+            assert "ai-rollback" in skills
+            assert "ai-repo-health" in skills
+
+
+class TestScaffoldWithRepoType:
+    def test_claude_library_main_skills(self, tmp_path):
+        scaffold_claude(
+            tmp_path,
+            repo_type=RepoType.LIBRARY,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        skills_dir = tmp_path / ".claude" / "skills"
+        assert not (skills_dir / "ai-promote").exists()
+        assert not (skills_dir / "ai-setup-oidc").exists()
+        assert not (skills_dir / "ai-mono-status").exists()
+        assert (skills_dir / "ai-pick-issue" / "SKILL.md").is_file()
+        assert (skills_dir / "ai-standardize-renovate" / "SKILL.md").is_file()
+
+    def test_claude_iac_dev_skills(self, tmp_path):
+        scaffold_claude(
+            tmp_path,
+            repo_type=RepoType.IAC,
+            branch_strategy=BranchStrategy.DEV,
+        )
+        skills_dir = tmp_path / ".claude" / "skills"
+        assert (skills_dir / "ai-promote" / "SKILL.md").is_file()
+        assert (skills_dir / "ai-setup-oidc" / "SKILL.md").is_file()
+        assert not (skills_dir / "ai-mono-status").exists()
+
+    def test_claude_monorepo_skills(self, tmp_path):
+        scaffold_claude(
+            tmp_path,
+            repo_type=RepoType.MONOREPO,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        skills_dir = tmp_path / ".claude" / "skills"
+        assert (skills_dir / "ai-mono-status" / "SKILL.md").is_file()
+        assert (skills_dir / "ai-mono-sync" / "SKILL.md").is_file()
+        assert (skills_dir / "ai-mono-init" / "SKILL.md").is_file()
+        assert (skills_dir / "ai-mono-health" / "SKILL.md").is_file()
+        assert (skills_dir / "ai-mono-foreach" / "SKILL.md").is_file()
+        assert not (skills_dir / "ai-promote").exists()
+        assert not (skills_dir / "ai-standardize-renovate").exists()
+
+    def test_claude_none_delivers_all_original_skills(self, tmp_path):
+        scaffold_claude(tmp_path, repo_type=None, branch_strategy=None)
+        skills_dir = tmp_path / ".claude" / "skills"
+        for skill_name in CLAUDE_SKILL_DIRS:
+            assert (skills_dir / skill_name / "SKILL.md").is_file()
+
+    def test_stale_skills_removed_on_type_change(self, tmp_path):
+        # First scaffold with all skills
+        scaffold_claude(
+            tmp_path,
+            repo_type=RepoType.IAC,
+            branch_strategy=BranchStrategy.DEV,
+        )
+        skills_dir = tmp_path / ".claude" / "skills"
+        assert (skills_dir / "ai-promote" / "SKILL.md").is_file()
+
+        # Switch to monorepo -- ai-promote should be removed
+        scaffold_claude(
+            tmp_path,
+            overwrite=True,
+            repo_type=RepoType.MONOREPO,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        assert not (skills_dir / "ai-promote").exists()
+        assert (skills_dir / "ai-mono-status" / "SKILL.md").is_file()
+
+    def test_opencode_monorepo_skills(self, tmp_path):
+        scaffold_opencode(
+            tmp_path,
+            repo_type=RepoType.MONOREPO,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        skills_dir = tmp_path / ".agents" / "skills"
+        assert (skills_dir / "ai-mono-status" / "SKILL.md").is_file()
+        assert not (skills_dir / "ai-promote").exists()
+
+    def test_codex_library_skills(self, tmp_path):
+        scaffold_codex(
+            tmp_path,
+            repo_type=RepoType.LIBRARY,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        skills_dir = tmp_path / ".agents" / "skills"
+        assert not (skills_dir / "ai-promote").exists()
+        assert (skills_dir / "ai-pick-issue" / "SKILL.md").is_file()
+
+
+class TestNotesTemplateSelection:
+    def test_library_notes(self, tmp_path):
+        scaffold_project(
+            tmp_path,
+            repo_type=RepoType.LIBRARY,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        content = (tmp_path / "NOTES.md").read_text()
+        assert "## Publishing" in content
+        assert "## Submodule Map" not in content
+
+    def test_iac_notes(self, tmp_path):
+        scaffold_project(
+            tmp_path,
+            repo_type=RepoType.IAC,
+            branch_strategy=BranchStrategy.DEV,
+        )
+        content = (tmp_path / "NOTES.md").read_text()
+        assert "## Deployment" in content
+        assert "ai-promote" in content
+
+    def test_monorepo_notes(self, tmp_path):
+        scaffold_project(
+            tmp_path,
+            repo_type=RepoType.MONOREPO,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        content = (tmp_path / "NOTES.md").read_text()
+        assert "## Submodule Map" in content
+        assert "augint-mono" in content
+
+    def test_none_type_uses_default_notes(self, tmp_path):
+        scaffold_project(tmp_path, repo_type=None)
+        content = (tmp_path / "NOTES.md").read_text()
+        assert "## Project Overview" in content
+        assert "## Submodule Map" not in content
+        assert "## Publishing" not in content
+
+
+class TestProjectTomlContent:
+    def test_library_toml_has_project_section(self, tmp_path):
+        scaffold_project(
+            tmp_path,
+            repo_type=RepoType.LIBRARY,
+            branch_strategy=BranchStrategy.MAIN,
+        )
+        content = (tmp_path / "ai-shell.toml").read_text()
+        assert 'repo_type = "library"' in content
+        assert 'branch_strategy = "main"' in content
+        # Active [project] section should not have dev_branch when strategy is main
+        project_section = content.split("\n\n")[0]  # first block = [project]
+        assert "dev_branch" not in project_section
+
+    def test_iac_dev_toml_has_dev_branch(self, tmp_path):
+        scaffold_project(
+            tmp_path,
+            repo_type=RepoType.IAC,
+            branch_strategy=BranchStrategy.DEV,
+            dev_branch="staging",
+        )
+        content = (tmp_path / "ai-shell.toml").read_text()
+        assert 'repo_type = "iac"' in content
+        assert 'branch_strategy = "dev"' in content
+        assert 'dev_branch = "staging"' in content
+
+    def test_none_type_toml_no_project_section(self, tmp_path):
+        scaffold_project(tmp_path, repo_type=None)
+        content = (tmp_path / "ai-shell.toml").read_text()
+        assert "[project]" not in content or "# [project]" in content


### PR DESCRIPTION
## Summary
- Add `--lib`/`--iac`/`--mono` flags to `ai-shell init` and per-tool scaffold commands
- Two-axis config: `repo_type` (library/iac/monorepo) + `branch_strategy` (main/dev) persisted in `ai-shell.toml` `[project]` section
- Deliver different skill sets per repo type (library excludes ai-promote/ai-setup-oidc, monorepo gets 5 new coordination skills)
- Interactive prompt for repo type and branch strategy when no flags provided on fresh init
- Three new NOTES.md templates: library (publishing focus), iac (deployment focus), monorepo (submodule coordination)
- Five new monorepo skills: ai-mono-status, ai-mono-sync, ai-mono-init, ai-mono-health, ai-mono-foreach
- Monorepo skills read tracked branch from `.gitmodules` to correctly handle IaC submodules on dev vs library submodules on main

## Test plan
- [x] All 245 existing + new tests pass
- [x] 95% code coverage
- [x] Pre-commit hooks pass (ruff, mypy, yaml, whitespace)
- [x] Backward compatible: repos without `[project]` section get all 17 original skills