### PR TITLE
feat(scaffold): rewrite ai-mono-* skills for CLI --json output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -165,7 +165,8 @@
       "Bash(prettier:*)",
       "Bash(tsc:*)",
       "Bash(jest:*)",
-      "Bash(vitest:*)"
+      "Bash(vitest:*)",
+      "Bash(ai-mono:*)"
     ],
     "deny": [
       "Write(poetry.lock)",

--- a/.claude/skills/ai-prepare-branch/SKILL.md
+++ b/.claude/skills/ai-prepare-branch/SKILL.md
@@ -60,7 +60,27 @@ Report: "Repo pattern: [dev-based|main-only]. Base branch: [branch]. PR target: 
 CURRENT_BRANCH=$(git branch --show-current)
 ```
 
-**Three-state check:**
+**First: detect already-merged work branches.**
+
+If on a work branch (not main/dev/staging), check whether its PR was already merged:
+
+```bash
+MERGED_PR=$(gh pr list --head $CURRENT_BRANCH --state merged --json number -q '.[0].number' 2>/dev/null)
+```
+
+If `MERGED_PR` is non-empty, this branch is stale (merged PRs + semantic-release version bumps create new commits on the target, so the old branch diverges). Handle automatically:
+
+- **No uncommitted changes**: Report "Branch $CURRENT_BRANCH was merged via PR #$MERGED_PR. Switching to $BASE." Then `git checkout $BASE` and `git branch -D $CURRENT_BRANCH`. Proceed to step 4.
+- **Uncommitted changes present**: These are new work started on a stale branch. Stash, switch, delete:
+  ```bash
+  git stash push -m "WIP: New work from stale branch $CURRENT_BRANCH"
+  git checkout $BASE
+  git branch -D $CURRENT_BRANCH
+  ```
+  Report: "Branch $CURRENT_BRANCH was merged via PR #$MERGED_PR. Stashed your uncommitted changes and switched to $BASE. Changes will be unstashed onto the new branch."
+  After step 6 (new branch created), run `git stash pop`.
+
+**Then: three-state check (only reached if branch was NOT already merged):**
 
 1. **On main/dev** - proceed normally (happy path)
 2. **On a work branch with no uncommitted changes and no unpushed commits** - offer to switch

--- a/.claude/skills/ai-submit-work/SKILL.md
+++ b/.claude/skills/ai-submit-work/SKILL.md
@@ -328,9 +328,10 @@ gh pr create \
 ## Issue
 <Closes #N or Refs #N if applicable>"
 
-# Set automerge
+# Set automerge -- use --merge (not --squash) to preserve commit ancestry
+# for clean promotion and release sync across long-lived branches
 PR_NUMBER=$(gh pr view --json number -q .number)
-gh pr merge --auto --squash $PR_NUMBER
+gh pr merge --auto --merge $PR_NUMBER
 ```
 
 ## 8. Final Output and Automatic Transition
@@ -340,7 +341,7 @@ Submitted: feat(cli): add metrics dashboard endpoint
 
 PR: https://github.com/owner/repo/pull/99
 Target: dev
-Automerge: enabled (squash)
+Automerge: enabled (merge)
 Status checks: monitoring...
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Hooks run automatically: YAML check, trailing whitespace, end-of-file newline, `
 
 ## Critical Rules
 
-- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on `main`. Use merge commits only.
+- **No rebase on main**: NEVER use `git pull --rebase` or `git rebase` on the default branch. Use merge commits only.
 - **No manual versioning**: NEVER manually edit version numbers. Python Semantic Release owns versioning via conventional commits. Version in `pyproject.toml` and `src/ai_shell/__init__.py`. Tag format: `augint-shell-v{version}`.
 - **No lock file edits**: NEVER directly write text into lock files (uv.lock, package-lock.json, poetry.lock, yarn.lock). Always use package manager commands (`uv lock`, `uv add`, `npm install`) to regenerate them. When a package manager command updates a lock file, ALWAYS stage and include it in the commit -- lock file changes must never be left uncommitted.
 - **No .env commits**: NEVER commit .env files. Use .env.example for templates.
@@ -75,7 +75,7 @@ git log --oneline -10         # Recent commits
 # GitHub CLI
 gh issue list --state open    # View open issues
 gh pr create                  # Create pull request
-gh pr merge --auto --squash   # Enable automerge
+gh pr merge --auto --merge    # Enable automerge
 gh run list                   # List workflow runs
 gh run view <id>              # View run details
 gh run watch <id>             # Watch run in real-time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,4 +124,5 @@ upload_to_vcs_release = false
 [dependency-groups]
 dev = [
     "augint-github>=1.3.1",
+    "augint-mono>=0.1.2",
 ]

--- a/src/ai_shell/templates/agents/skills/ai-mono-foreach/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-foreach/SKILL.md
@@ -8,67 +8,68 @@ Run a command in every submodule: $ARGUMENTS
 
 Iterates all submodules, runs the specified command or skill in each, and aggregates results.
 
+**When to use foreach vs working in each submodule manually:**
+- Use foreach for **read-only checks**: `git status`, test runs, dependency audits, standards checks
+- Use **manual `cd` into each submodule** for development work: code changes, dependency updates, branch management, PR creation
+
 ## Usage Examples
 - `/ai-mono-foreach git status` - Check git status in each submodule
 - `/ai-mono-foreach uv sync` - Install deps in each Python submodule
 - `/ai-mono-foreach /ai-standardize-repo --status` - Check standards in each submodule
 
-## 1. Verify Monorepo
+## 1. Detect Command Type
+
+Parse `$ARGUMENTS` to determine if it is:
+- **Shell command** (does NOT start with `/`): delegate to CLI
+- **Skill invocation** (starts with `/`): handle with AI iteration (step 3b)
+
+## 2. Get Submodule List
+
+If using the CLI path, the CLI handles submodule discovery. If using the AI path, list submodules:
 
 ```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
+ai-mono status --json | jq -r '.submodules[].name'
 ```
 
-## 2. Parse Arguments
-
-The command to run is everything in `$ARGUMENTS`. It can be:
-- A shell command: `git status`, `uv sync`, `npm install`
-- A skill invocation: `/ai-standardize-repo --status`
-- Any executable command
-
-## 3. Iterate Submodules
+## 3a. Shell Command Path (CLI)
 
 ```bash
-SUBMODULES=$(git submodule status | awk '{print $2}')
-TOTAL=$(echo "$SUBMODULES" | wc -l)
-PASS=0
-FAIL=0
-SKIP=0
-
-for SUBMODULE in $SUBMODULES; do
-    echo ""
-    echo "=== $SUBMODULE ==="
-
-    if [ ! -d "$SUBMODULE" ]; then
-        echo "SKIP: Directory not found (submodule not initialized)"
-        SKIP=$((SKIP + 1))
-        continue
-    fi
-
-    cd "$SUBMODULE"
-
-    # Run the command
-    # If it's a skill invocation (starts with /), handle accordingly
-    # If it's a shell command, run it directly
-    eval "$ARGUMENTS"
-    EXIT_CODE=$?
-
-    if [ $EXIT_CODE -eq 0 ]; then
-        echo "PASS"
-        PASS=$((PASS + 1))
-    else
-        echo "FAIL (exit code: $EXIT_CODE)"
-        FAIL=$((FAIL + 1))
-    fi
-
-    cd ..
-done
+ai-mono foreach --json $ARGUMENTS
 ```
+
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
+
+**JSON response:**
+```json
+{
+  "command": "str",
+  "results": [
+    {"name": "str", "status": "PASS|FAIL|SKIP", "exit_code": 0, "stdout": "str", "stderr": "str"}
+  ],
+  "summary": {"passed": 0, "failed": 0, "skipped": 0}
+}
+```
+
+To filter to a single submodule, pass `--submodule <name>` before `--`:
+```bash
+ai-mono foreach --json --submodule backend -- git status
+```
+
+## 3b. Skill Invocation Path (AI-Only)
+
+The CLI cannot run AI skills. For skill invocations, iterate submodules manually:
+
+For each submodule:
+1. `cd` into the submodule directory
+2. Invoke the skill (e.g., `/ai-standardize-repo --status`)
+3. Record the result (pass/fail/output)
+4. Return to monorepo root
+
+Do NOT stop on first failure -- always complete all submodules.
 
 ## 4. Aggregate Results
+
+Format results as a table:
 
 ```
 Foreach Results
@@ -89,12 +90,12 @@ Summary: 2 passed, 1 failed, 0 skipped
 ## 5. Handle Failures
 
 If any submodule failed:
-- List the failed submodules
+- List the failed submodules with their stderr output
 - Suggest investigating: "Check failed submodule: `cd infra && <command>`"
-- Do NOT stop on first failure -- always complete all submodules
+- For common failures, suggest specific fixes
 
 ## Error Handling
-- **Not a monorepo**: Clear error
+- **Not a monorepo**: CLI exits with error -- relay the message
 - **No arguments**: Ask what command to run
-- **Submodule not initialized**: Skip with warning, count as skipped
-- **Command not found**: Fail that submodule, continue to next
+- **Submodule not initialized**: CLI marks as SKIP -- note in output, suggest `/ai-mono-init`
+- **Command not found**: CLI marks as FAIL with exit code 127 -- suggest checking the command

--- a/src/ai_shell/templates/agents/skills/ai-mono-health/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-health/SKILL.md
@@ -6,134 +6,64 @@ argument-hint: "[--submodule <name>]"
 
 Analyze cross-repo health across all submodules: $ARGUMENTS
 
-Checks dependency overlap, version alignment, submodule pointer freshness, and standards compliance across all submodules.
+Checks submodule pointer freshness, branch configuration, standards compliance, and dependency overlap across all submodules.
 
 ## Usage Examples
 - `/ai-mono-health` - Full health analysis
 - `/ai-mono-health --submodule backend` - Health check for one submodule
 
-## 1. Verify Monorepo
+## 1. Get Health Data
 
 ```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
+ai-mono health --json $ARGUMENTS
 ```
 
-## 2. Resolve Tracked Branch Per Submodule
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
-
-```bash
-tracked_branch_for() {
-    local sub="$1"
-    local branch
-    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    echo "main"
+**JSON response:**
+```json
+{
+  "freshness": [
+    {"name": "str", "tracked_branch": "str", "behind": 0, "status": "up_to_date|stale"}
+  ],
+  "branch_config": [
+    {"name": "str", "configured_branch": "str or null", "status": "ok|missing"}
+  ],
+  "standards": [
+    {"name": "str", "pre_commit": true, "editorconfig": true, "ci_workflows": true}
+  ],
+  "recommendations": ["str"]
 }
 ```
 
-## 3. Submodule Pointer Freshness
+## 2. Dependency Overlap Analysis (AI-Only)
 
-For each submodule, check how far behind the pointer is from its tracked branch:
+This analysis is NOT in the CLI -- perform it directly by reading dependency files in each submodule.
 
-```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    TRACKED=$(tracked_branch_for "$SUBMODULE")
-    POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
-    cd "$SUBMODULE"
-    git fetch --all --prune 2>/dev/null
-    REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
-    if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
-        BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
-        DAYS=$(git log -1 --format="%cr" "$POINTER_SHA")
-        echo "$SUBMODULE ($TRACKED): $BEHIND commits behind (pointer from $DAYS)"
-    else
-        echo "$SUBMODULE ($TRACKED): up to date"
-    fi
-    cd ..
-done
-```
+For each submodule, scan for dependency files:
+- **Python**: `pyproject.toml` (under `[project.dependencies]` and `[dependency-groups]`), `requirements.txt`
+- **Node**: `package.json` (under `dependencies` and `devDependencies`)
+- **Terraform**: `versions.tf` (provider version constraints)
 
-## 4. Branch Configuration Audit
+Cross-reference shared dependencies across submodules:
+- Same package at different versions
+- Outdated versions relative to other submodules
+- Conflicting version constraints
 
-Check that each submodule has a tracked branch configured in `.gitmodules`:
+## 3. Build Health Report
 
-```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
-    if [ -z "$BRANCH" ]; then
-        echo "[WARN] $SUBMODULE: no branch set in .gitmodules (defaults to remote HEAD)"
-        echo "  Fix: git config -f .gitmodules submodule.${SUBMODULE}.branch <branch>"
-    else
-        echo "[OK] $SUBMODULE: tracks $BRANCH"
-    fi
-done
-```
-
-## 5. Dependency Overlap Analysis
-
-Scan each submodule for dependency files and find shared dependencies:
-
-```bash
-# Python repos: pyproject.toml, requirements.txt
-# Node repos: package.json
-# Terraform: versions.tf
-
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    if [ -f "$SUBMODULE/pyproject.toml" ]; then
-        echo "[$SUBMODULE] Python project"
-        # Extract dependencies
-    elif [ -f "$SUBMODULE/package.json" ]; then
-        echo "[$SUBMODULE] Node project"
-        # Extract dependencies
-    fi
-done
-```
-
-Cross-reference shared dependencies and flag version mismatches:
-- Same package at different versions across submodules
-- Outdated versions relative to latest available
-
-## 6. Standards Compliance
-
-For each submodule, check:
-- Pre-commit config exists and is consistent
-- CI workflows follow standard patterns
-- .editorconfig is present and consistent
-- .gitignore covers standard patterns
-
-```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    echo "--- $SUBMODULE ---"
-    [ -f "$SUBMODULE/.pre-commit-config.yaml" ] && echo "[OK] pre-commit" || echo "[MISSING] pre-commit"
-    [ -f "$SUBMODULE/.editorconfig" ] && echo "[OK] editorconfig" || echo "[MISSING] editorconfig"
-    [ -d "$SUBMODULE/.github/workflows" ] && echo "[OK] CI workflows" || echo "[MISSING] CI workflows"
-done
-```
-
-## 7. Health Report
+Combine CLI data with the dependency analysis:
 
 ```
 Monorepo Health Report
 ======================
 
 Pointer Freshness:
-  | Submodule  | Tracks | Status     | Behind | Last Updated |
-  |------------|--------|------------|--------|--------------|
-  | backend    | dev    | stale      | 5      | 3 days ago   |
-  | frontend   | dev    | up to date | 0      | today        |
-  | shared-lib | main   | up to date | 0      | today        |
+  | Submodule  | Tracks | Status     | Behind |
+  |------------|--------|------------|--------|
+  | backend    | dev    | stale      | 5      |
+  | frontend   | dev    | up to date | 0      |
+  | shared-lib | main   | up to date | 0      |
 
 Branch Config:
   | Submodule  | .gitmodules branch | Status |
@@ -146,7 +76,7 @@ Dependency Overlap:
   | Package   | backend | frontend | Aligned? |
   |-----------|---------|----------|----------|
   | pydantic  | 2.9.0   | -        | n/a      |
-  | requests  | 2.32.0  | -        | n/a      |
+  | boto3     | 1.35.0  | 1.34.0   | NO       |
 
 Standards Compliance:
   | Check       | backend | frontend | infra |
@@ -154,14 +84,18 @@ Standards Compliance:
   | pre-commit  | OK      | OK       | MISS  |
   | editorconfig| OK      | OK       | OK    |
   | CI          | OK      | OK       | OK    |
-
-Recommendations:
-  1. Update stale pointers: /ai-mono-sync
-  2. Set tracked branch for shared-lib: git config -f .gitmodules submodule.shared-lib.branch main
-  3. Add pre-commit to infra: cd infra && /ai-standardize-precommit
 ```
 
+## 4. Prioritized Recommendations
+
+Merge CLI `recommendations` with dependency analysis findings. Order by urgency:
+
+1. **Failing standards** (missing pre-commit, CI): suggest specific skills (e.g., "Add pre-commit to infra: `cd infra && /ai-standardize-precommit`")
+2. **Stale pointers**: suggest `/ai-mono-sync`
+3. **Missing branch config**: suggest `git config -f .gitmodules submodule.<name>.branch <branch>`
+4. **Dependency mismatches**: flag which packages are out of alignment and suggest updating
+
 ## Error Handling
-- **Not a monorepo**: Clear error
+- **Not a monorepo**: CLI exits with error -- relay the message
 - **Submodule not initialized**: Suggest `/ai-mono-init`
-- **No dependency files found**: Skip dependency analysis for that submodule
+- **No dependency files found**: Skip dependency analysis for that submodule, note in output

--- a/src/ai_shell/templates/agents/skills/ai-mono-init/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-init/SKILL.md
@@ -1,106 +1,68 @@
 ---
 name: ai-mono-init
 description: First-time monorepo development setup. Initializes submodules and verifies environment. Use when setting up a monorepo for development or saying 'set up this monorepo'.
-argument-hint: ""
+argument-hint: "[--submodule <name>]"
 ---
 
 Set up this monorepo for development: $ARGUMENTS
 
-Initializes all submodules, verifies tracked branches are configured in `.gitmodules`, checks .env files, and guides the user through per-submodule AI tool setup.
+Initializes all submodules, verifies tracked branches are configured in `.gitmodules`, checks .env files, and guides per-submodule AI tool setup.
 
 ## Usage Examples
 - `/ai-mono-init` - Full first-time setup
+- `/ai-mono-init --submodule backend` - Check one submodule only
 
-## 1. Verify Monorepo
-
-```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
-```
-
-## 2. Initialize Submodules
+## 1. Run Init
 
 ```bash
-git submodule update --init --recursive
+ai-mono init --json $ARGUMENTS
 ```
 
-Report which submodules were initialized.
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-## 3. Verify Tracked Branches
+**JSON response:**
+```json
+{
+  "submodules": [
+    {"name": "str", "tracked_branch": "str", "branch_configured": true, "env_status": "ok|missing|no_template"}
+  ],
+  "warnings": ["str"],
+  "deps_installed": true
+}
+```
 
-Each submodule should have a `branch` configured in `.gitmodules` so that `/ai-mono-sync` knows which branch to track. IaC repos with a dev-to-main workflow should track `dev`; library repos should track `main`.
+## 2. Configure Unconfigured Branches
 
+For each submodule where `branch_configured` is false, look inside the submodule directory to detect its type, then suggest the correct tracked branch:
+
+- **IaC / backend / web service**: has `*.tf` files, `Dockerfile`, `docker-compose.yml`, `serverless.yml`, or deployment configs → suggest tracking `dev` (these use a dev-to-main promotion workflow)
+- **Library / package**: has `pyproject.toml` with `[build-system]`, or `package.json` with a `main` field → suggest tracking `main` (libraries release directly from main)
+- **Unknown**: ask the user which branch this submodule releases from
+
+Explain to the user in plain terms: "The tracked branch tells the monorepo which branch to follow for updates. Backend services typically use 'dev' because changes go through staging first. Libraries use 'main' because they publish directly."
+
+Set the branch:
 ```bash
-NEEDS_BRANCH_CONFIG=()
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
-    if [ -z "$BRANCH" ]; then
-        NEEDS_BRANCH_CONFIG+=("$SUBMODULE")
-        echo "[WARN] $SUBMODULE: no branch set in .gitmodules"
-    else
-        echo "[OK] $SUBMODULE: tracks $BRANCH"
-    fi
-done
+git config -f .gitmodules submodule.<name>.branch <branch>
 ```
 
-If any submodules are missing branch config, guide the user:
-
-```
-The following submodules have no tracked branch in .gitmodules:
-  - frontend
-  - shared-lib
-
-Set the branch each submodule should track:
-  - IaC repos (dev-to-main workflow): git config -f .gitmodules submodule.frontend.branch dev
-  - Library repos (main-only):        git config -f .gitmodules submodule.shared-lib.branch main
-
-Then commit the change:
-  git add .gitmodules && git commit -m "chore: set tracked branches for submodules"
-```
-
-Ask the user which branch each unconfigured submodule should track, then run the `git config -f .gitmodules` commands and commit.
-
-## 4. Verify Environment Files
-
-For each submodule, check for `.env`:
-
+After setting all branches, stage and commit:
 ```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    if [ -f "$SUBMODULE/.env" ]; then
-        echo "[OK] $SUBMODULE/.env exists"
-    elif [ -f "$SUBMODULE/.env.example" ]; then
-        echo "[WARN] $SUBMODULE/.env missing -- copy from .env.example:"
-        echo "  cp $SUBMODULE/.env.example $SUBMODULE/.env"
-    else
-        echo "[WARN] $SUBMODULE has no .env or .env.example"
-    fi
-done
+git add .gitmodules
+git commit -m "chore: set tracked branches for submodules"
 ```
 
-Also check the monorepo root:
-```bash
-if [ -f ".env" ]; then
-    echo "[OK] Monorepo root .env exists"
-elif [ -f ".env.example" ]; then
-    echo "[WARN] Root .env missing -- copy from .env.example"
-else
-    echo "[INFO] No .env at monorepo root (may not be needed)"
-fi
-```
+## 3. Fix Environment Files
 
-## 5. Check Dev Dependencies
+For each submodule where `env_status` is:
+- `missing` (has .env.example but no .env): `cp <submodule>/.env.example <submodule>/.env`
+- `no_template`: note that no .env may be needed, or ask the user
 
-If the monorepo root has a `pyproject.toml`:
-```bash
-if [ -f "pyproject.toml" ]; then
-    echo "Installing monorepo dev dependencies..."
-    uv sync
-fi
-```
+Also check root .env if warnings mention it.
 
-## 6. Report Setup Status
+## 4. Report Setup Status
+
+Format results as:
 
 ```
 Monorepo setup complete!
@@ -124,7 +86,13 @@ Next steps:
   3. Check monorepo status: /ai-mono-status
 ```
 
+Use the repo type detection from step 2 to suggest `--iac` vs `--lib` for each submodule:
+- `--iac` for backends, web services, and infrastructure (repos that deploy)
+- `--lib` for libraries and packages (repos that publish)
+
+This is a one-time setup. After init, use `/ai-mono-status` for ongoing monitoring.
+
 ## Error Handling
-- **Not a monorepo**: Clear error
-- **Submodule clone fails**: Report which submodule failed, suggest checking SSH keys / access
-- **uv not available**: Skip dependency install, suggest installing uv
+- **Not a monorepo**: CLI exits with error -- relay the message
+- **Submodule clone fails**: Suggest checking SSH keys / access
+- **Specified submodule not found**: CLI exits with error -- relay and list available submodules

--- a/src/ai_shell/templates/agents/skills/ai-mono-status/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-status/SKILL.md
@@ -12,82 +12,36 @@ Provides a unified view of work happening across all submodules: open PRs, pipel
 - `/ai-mono-status` - Full status across all submodules
 - `/ai-mono-status --submodule backend` - Status for one submodule only
 
-## 1. Detect Submodules
+## 1. Get Status Data
 
 ```bash
-# Verify this is a monorepo (has .gitmodules)
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    echo "Run this command from the monorepo root directory."
-    exit 1
-fi
-
-git submodule status --recursive
+ai-mono status --json $ARGUMENTS
 ```
 
-Parse each submodule: name, current SHA, path.
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-## 2. Resolve Tracked Branch Per Submodule
-
-Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
-
-```bash
-# Read the tracked branch from .gitmodules (falls back to remote HEAD, then "main")
-tracked_branch_for() {
-    local sub="$1"
-    # 1. Check .gitmodules branch setting
-    local branch
-    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    # 2. Fall back to the submodule's remote HEAD
-    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    # 3. Default to main
-    echo "main"
+**JSON response:**
+```json
+{
+  "submodules": [
+    {
+      "name": "str",
+      "tracked_branch": "str",
+      "pointer_sha": "full SHA",
+      "remote_sha": "full SHA or null",
+      "behind": 0,
+      "open_prs": 0,
+      "ci_status": "passing|failing|unknown"
+    }
+  ],
+  "summary": {"total": 0, "stale": 0, "up_to_date": 0},
+  "recommendations": ["str"]
 }
 ```
 
-## 3. Per-Submodule Status
+## 2. Format Dashboard
 
-For each submodule:
-
-```bash
-SUBMODULE="backend"  # example
-TRACKED=$(tracked_branch_for "$SUBMODULE")
-
-# Current pointer vs tracked branch HEAD
-POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
-cd "$SUBMODULE"
-git fetch --all --prune 2>/dev/null
-
-REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
-
-# Commits behind
-if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
-    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" 2>/dev/null | wc -l)
-    echo "$SUBMODULE: $BEHIND commits behind origin/$TRACKED"
-else
-    echo "$SUBMODULE: up to date (tracking $TRACKED)"
-fi
-
-# Open PRs
-gh pr list --state open --json number,title,author,updatedAt --limit 5
-
-# Latest CI run
-gh run list --limit 1 --json status,conclusion,name,createdAt
-
-cd ..
-```
-
-## 4. Aggregated Dashboard
-
-Format output as a table:
+Present results as a table:
 
 ```
 Monorepo Status
@@ -105,17 +59,27 @@ Summary:
   - 2 submodules with stale pointers
 ```
 
-## 5. Suggested Next Actions
+Use the first 7 characters of pointer_sha for display.
 
-Based on status, suggest:
+## 3. AI Analysis
+
+Go beyond the CLI's raw data:
+
+- **Priority ordering**: Which submodule needs attention most urgently? Failing CI > stale pointers > open PRs needing review.
+- **Cross-referencing**: Do any open PRs correspond to stale pointers? (e.g., a merged PR in a submodule that hasn't been synced yet)
+- **Blocked work detection**: Are stale pointers blocking other submodules' work?
+
+## 4. Suggested Next Actions
+
+Based on status, suggest specific actions:
 - If submodules are behind: "Run `/ai-mono-sync` to update pointers"
 - If CI is failing: "Check frontend: `cd frontend && /ai-monitor-pipeline`"
 - If PRs need review: List them with links
-- If a submodule has no `branch` set in `.gitmodules`: "Consider setting tracked branch: `git config -f .gitmodules submodule.backend.branch dev`"
 - If everything is clean: "All submodules are up to date. No action needed."
 
+Include the CLI's `recommendations` array but enhance with skill-specific suggestions.
+
 ## Error Handling
-- **Not a monorepo**: Clear error pointing to monorepo root
-- **Submodule not initialized**: Suggest `git submodule update --init`
-- **No GitHub remote**: Skip PR/CI checks for that submodule, warn
-- **Rate limiting**: Warn and show partial results
+- **Not a monorepo**: CLI exits with error -- relay the message
+- **Submodule not initialized**: Suggest `/ai-mono-init`
+- **No GitHub remote / gh CLI missing**: CLI warns and returns `open_prs: 0`, `ci_status: "unknown"` -- note this in output

--- a/src/ai_shell/templates/agents/skills/ai-mono-sync/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-mono-sync/SKILL.md
@@ -8,108 +8,71 @@ Sync submodule pointers to their latest tracked branch HEAD: $ARGUMENTS
 
 Updates submodule pointers to the latest commit on each submodule's tracked branch (configured in `.gitmodules`), optionally staging and committing the pointer changes.
 
+Sync after PRs are merged in a submodule, not while feature branches are in progress. Syncing picks up whatever is on the tracked branch (typically `dev` or `main`).
+
 ## Usage Examples
 - `/ai-mono-sync` - Show what would change (dry run)
 - `/ai-mono-sync --commit` - Update pointers and commit changes
 - `/ai-mono-sync --submodule backend` - Sync only one submodule
 
-## 1. Verify Monorepo
+## 1. Preview Changes
 
 ```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
+ai-mono sync --json $ARGUMENTS
 ```
 
-## 2. Resolve Tracked Branch Per Submodule
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+If `--commit` was passed in $ARGUMENTS, skip to step 3.
 
-```bash
-tracked_branch_for() {
-    local sub="$1"
-    local branch
-    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    echo "main"
+**JSON response:**
+```json
+{
+  "submodules": [
+    {
+      "name": "str",
+      "tracked_branch": "str",
+      "pointer_sha": "full SHA",
+      "remote_sha": "full SHA or null",
+      "behind": 0,
+      "updated": false
+    }
+  ],
+  "committed": false,
+  "commit_sha": null
 }
 ```
 
-## 3. Fetch All Submodules
+## 2. Show Changes and Ask for Confirmation
 
-```bash
-git submodule update --init --recursive
-git submodule foreach git fetch --all --prune
-```
-
-## 4. Check Each Submodule
-
-For each submodule, compare the current pointer with the tracked branch HEAD:
-
-```bash
-SUBMODULE="backend"
-TRACKED=$(tracked_branch_for "$SUBMODULE")
-POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
-
-cd "$SUBMODULE"
-REMOTE_SHA=$(git rev-parse "origin/$TRACKED")
-
-if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
-    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
-    NEW_COMMITS=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" --limit 5)
-    echo "$SUBMODULE ($TRACKED): $BEHIND new commits"
-    echo "$NEW_COMMITS"
-fi
-cd ..
-```
-
-## 5. Show Changes Before Acting
-
-Display a summary of what would change:
+Display what would change:
 
 ```
 Submodule pointer updates:
-  backend  (tracks dev):   a1b2c3d -> x9y8z7w  (3 commits)
-  frontend (tracks dev):   d4e5f6g -> d4e5f6g  (up to date)
+  backend  (tracks dev):    a1b2c3d -> x9y8z7w  (3 commits)
+  frontend (tracks dev):    d4e5f6g -> d4e5f6g  (up to date)
   shared-lib (tracks main): h7i8j9k -> m3n4o5p  (1 commit)
 ```
 
-If `--commit` was NOT passed, stop here and ask: "Apply these changes? Run `/ai-mono-sync --commit` to update and commit."
+If any submodule is >20 commits behind, warn: "backend is 47 commits behind -- consider reviewing changes before syncing."
 
-## 6. Update Pointers
+If no submodules need updating: "All submodules are up to date. No action needed." Stop here.
 
-```bash
-# For each submodule that needs updating
-TRACKED=$(tracked_branch_for "$SUBMODULE")
-cd "$SUBMODULE"
-git checkout "$TRACKED"
-git pull origin "$TRACKED"
-cd ..
-```
+Otherwise, ask: "Apply these changes? Run `/ai-mono-sync --commit` to update and commit."
 
-## 7. Stage and Commit
+## 3. Apply Changes
+
+When `--commit` is in $ARGUMENTS (or user confirms):
 
 ```bash
-# Stage submodule pointer changes
-git add backend shared-lib  # only changed submodules
-
-# Build commit message listing what changed
-git commit -m "chore(deps): update submodule pointers
-
-- backend (dev): a1b2c3d -> x9y8z7w (3 commits)
-- shared-lib (main): h7i8j9k -> m3n4o5p (1 commit)"
+ai-mono sync --commit --json [--submodule "$NAME"]
 ```
 
-## 8. Final Output
+The CLI handles: fetching, updating pointers, staging, and committing with a `chore(deps): update submodule pointers` message listing each updated submodule.
+
+## 4. Report Results
+
+Parse the JSON response. If `committed` is true:
 
 ```
 Submodule pointers updated and committed.
@@ -120,13 +83,14 @@ Updated:
 Unchanged:
   - frontend (dev)
 
-Commit: chore(deps): update submodule pointers
+Commit: <commit_sha>
 Next: git push or /ai-submit-work
 ```
 
+If `committed` is false but updates were expected, warn that something went wrong.
+
 ## Error Handling
-- **Not a monorepo**: Clear error
-- **Submodule has local changes**: Warn and skip that submodule
-- **Submodule in detached HEAD**: Re-attach to tracked branch before updating
+- **Not a monorepo**: CLI exits with error -- relay the message
+- **Submodule has local changes**: CLI may fail to update -- warn and suggest stashing
 - **No changes**: Exit cleanly with "All submodules are up to date"
-- **No branch configured in .gitmodules**: Warn and fall back to remote HEAD or main
+- **Specified submodule not found**: CLI exits with error -- relay and list available submodules

--- a/src/ai_shell/templates/claude/settings.json
+++ b/src/ai_shell/templates/claude/settings.json
@@ -27,6 +27,7 @@
       "Bash(uv run pip-audit:*)",
       "Bash(uv run pip-licenses:*)",
       "Bash(uv export:*)",
+      "Bash(ai-mono:*)",
       "Bash(uv run:*)",
       "Bash(uv sync:*)",
       "Bash(uv build:*)",

--- a/src/ai_shell/templates/claude/skills/ai-mono-foreach/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-foreach/SKILL.md
@@ -8,67 +8,68 @@ Run a command in every submodule: $ARGUMENTS
 
 Iterates all submodules, runs the specified command or skill in each, and aggregates results.
 
+**When to use foreach vs working in each submodule manually:**
+- Use foreach for **read-only checks**: `git status`, test runs, dependency audits, standards checks
+- Use **manual `cd` into each submodule** for development work: code changes, dependency updates, branch management, PR creation
+
 ## Usage Examples
 - `/ai-mono-foreach git status` - Check git status in each submodule
 - `/ai-mono-foreach uv sync` - Install deps in each Python submodule
 - `/ai-mono-foreach /ai-standardize-repo --status` - Check standards in each submodule
 
-## 1. Verify Monorepo
+## 1. Detect Command Type
+
+Parse `$ARGUMENTS` to determine if it is:
+- **Shell command** (does NOT start with `/`): delegate to CLI
+- **Skill invocation** (starts with `/`): handle with AI iteration (step 3b)
+
+## 2. Get Submodule List
+
+If using the CLI path, the CLI handles submodule discovery. If using the AI path, list submodules:
 
 ```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
+ai-mono status --json | jq -r '.submodules[].name'
 ```
 
-## 2. Parse Arguments
-
-The command to run is everything in `$ARGUMENTS`. It can be:
-- A shell command: `git status`, `uv sync`, `npm install`
-- A skill invocation: `/ai-standardize-repo --status`
-- Any executable command
-
-## 3. Iterate Submodules
+## 3a. Shell Command Path (CLI)
 
 ```bash
-SUBMODULES=$(git submodule status | awk '{print $2}')
-TOTAL=$(echo "$SUBMODULES" | wc -l)
-PASS=0
-FAIL=0
-SKIP=0
-
-for SUBMODULE in $SUBMODULES; do
-    echo ""
-    echo "=== $SUBMODULE ==="
-
-    if [ ! -d "$SUBMODULE" ]; then
-        echo "SKIP: Directory not found (submodule not initialized)"
-        SKIP=$((SKIP + 1))
-        continue
-    fi
-
-    cd "$SUBMODULE"
-
-    # Run the command
-    # If it's a skill invocation (starts with /), handle accordingly
-    # If it's a shell command, run it directly
-    eval "$ARGUMENTS"
-    EXIT_CODE=$?
-
-    if [ $EXIT_CODE -eq 0 ]; then
-        echo "PASS"
-        PASS=$((PASS + 1))
-    else
-        echo "FAIL (exit code: $EXIT_CODE)"
-        FAIL=$((FAIL + 1))
-    fi
-
-    cd ..
-done
+ai-mono foreach --json $ARGUMENTS
 ```
+
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
+
+**JSON response:**
+```json
+{
+  "command": "str",
+  "results": [
+    {"name": "str", "status": "PASS|FAIL|SKIP", "exit_code": 0, "stdout": "str", "stderr": "str"}
+  ],
+  "summary": {"passed": 0, "failed": 0, "skipped": 0}
+}
+```
+
+To filter to a single submodule, pass `--submodule <name>` before `--`:
+```bash
+ai-mono foreach --json --submodule backend -- git status
+```
+
+## 3b. Skill Invocation Path (AI-Only)
+
+The CLI cannot run AI skills. For skill invocations, iterate submodules manually:
+
+For each submodule:
+1. `cd` into the submodule directory
+2. Invoke the skill (e.g., `/ai-standardize-repo --status`)
+3. Record the result (pass/fail/output)
+4. Return to monorepo root
+
+Do NOT stop on first failure -- always complete all submodules.
 
 ## 4. Aggregate Results
+
+Format results as a table:
 
 ```
 Foreach Results
@@ -89,12 +90,12 @@ Summary: 2 passed, 1 failed, 0 skipped
 ## 5. Handle Failures
 
 If any submodule failed:
-- List the failed submodules
+- List the failed submodules with their stderr output
 - Suggest investigating: "Check failed submodule: `cd infra && <command>`"
-- Do NOT stop on first failure -- always complete all submodules
+- For common failures, suggest specific fixes
 
 ## Error Handling
-- **Not a monorepo**: Clear error
+- **Not a monorepo**: CLI exits with error -- relay the message
 - **No arguments**: Ask what command to run
-- **Submodule not initialized**: Skip with warning, count as skipped
-- **Command not found**: Fail that submodule, continue to next
+- **Submodule not initialized**: CLI marks as SKIP -- note in output, suggest `/ai-mono-init`
+- **Command not found**: CLI marks as FAIL with exit code 127 -- suggest checking the command

--- a/src/ai_shell/templates/claude/skills/ai-mono-health/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-health/SKILL.md
@@ -6,134 +6,64 @@ argument-hint: "[--submodule <name>]"
 
 Analyze cross-repo health across all submodules: $ARGUMENTS
 
-Checks dependency overlap, version alignment, submodule pointer freshness, and standards compliance across all submodules.
+Checks submodule pointer freshness, branch configuration, standards compliance, and dependency overlap across all submodules.
 
 ## Usage Examples
 - `/ai-mono-health` - Full health analysis
 - `/ai-mono-health --submodule backend` - Health check for one submodule
 
-## 1. Verify Monorepo
+## 1. Get Health Data
 
 ```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
+ai-mono health --json $ARGUMENTS
 ```
 
-## 2. Resolve Tracked Branch Per Submodule
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
-
-```bash
-tracked_branch_for() {
-    local sub="$1"
-    local branch
-    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    echo "main"
+**JSON response:**
+```json
+{
+  "freshness": [
+    {"name": "str", "tracked_branch": "str", "behind": 0, "status": "up_to_date|stale"}
+  ],
+  "branch_config": [
+    {"name": "str", "configured_branch": "str or null", "status": "ok|missing"}
+  ],
+  "standards": [
+    {"name": "str", "pre_commit": true, "editorconfig": true, "ci_workflows": true}
+  ],
+  "recommendations": ["str"]
 }
 ```
 
-## 3. Submodule Pointer Freshness
+## 2. Dependency Overlap Analysis (AI-Only)
 
-For each submodule, check how far behind the pointer is from its tracked branch:
+This analysis is NOT in the CLI -- perform it directly by reading dependency files in each submodule.
 
-```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    TRACKED=$(tracked_branch_for "$SUBMODULE")
-    POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
-    cd "$SUBMODULE"
-    git fetch --all --prune 2>/dev/null
-    REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
-    if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
-        BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
-        DAYS=$(git log -1 --format="%cr" "$POINTER_SHA")
-        echo "$SUBMODULE ($TRACKED): $BEHIND commits behind (pointer from $DAYS)"
-    else
-        echo "$SUBMODULE ($TRACKED): up to date"
-    fi
-    cd ..
-done
-```
+For each submodule, scan for dependency files:
+- **Python**: `pyproject.toml` (under `[project.dependencies]` and `[dependency-groups]`), `requirements.txt`
+- **Node**: `package.json` (under `dependencies` and `devDependencies`)
+- **Terraform**: `versions.tf` (provider version constraints)
 
-## 4. Branch Configuration Audit
+Cross-reference shared dependencies across submodules:
+- Same package at different versions
+- Outdated versions relative to other submodules
+- Conflicting version constraints
 
-Check that each submodule has a tracked branch configured in `.gitmodules`:
+## 3. Build Health Report
 
-```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
-    if [ -z "$BRANCH" ]; then
-        echo "[WARN] $SUBMODULE: no branch set in .gitmodules (defaults to remote HEAD)"
-        echo "  Fix: git config -f .gitmodules submodule.${SUBMODULE}.branch <branch>"
-    else
-        echo "[OK] $SUBMODULE: tracks $BRANCH"
-    fi
-done
-```
-
-## 5. Dependency Overlap Analysis
-
-Scan each submodule for dependency files and find shared dependencies:
-
-```bash
-# Python repos: pyproject.toml, requirements.txt
-# Node repos: package.json
-# Terraform: versions.tf
-
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    if [ -f "$SUBMODULE/pyproject.toml" ]; then
-        echo "[$SUBMODULE] Python project"
-        # Extract dependencies
-    elif [ -f "$SUBMODULE/package.json" ]; then
-        echo "[$SUBMODULE] Node project"
-        # Extract dependencies
-    fi
-done
-```
-
-Cross-reference shared dependencies and flag version mismatches:
-- Same package at different versions across submodules
-- Outdated versions relative to latest available
-
-## 6. Standards Compliance
-
-For each submodule, check:
-- Pre-commit config exists and is consistent
-- CI workflows follow standard patterns
-- .editorconfig is present and consistent
-- .gitignore covers standard patterns
-
-```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    echo "--- $SUBMODULE ---"
-    [ -f "$SUBMODULE/.pre-commit-config.yaml" ] && echo "[OK] pre-commit" || echo "[MISSING] pre-commit"
-    [ -f "$SUBMODULE/.editorconfig" ] && echo "[OK] editorconfig" || echo "[MISSING] editorconfig"
-    [ -d "$SUBMODULE/.github/workflows" ] && echo "[OK] CI workflows" || echo "[MISSING] CI workflows"
-done
-```
-
-## 7. Health Report
+Combine CLI data with the dependency analysis:
 
 ```
 Monorepo Health Report
 ======================
 
 Pointer Freshness:
-  | Submodule  | Tracks | Status     | Behind | Last Updated |
-  |------------|--------|------------|--------|--------------|
-  | backend    | dev    | stale      | 5      | 3 days ago   |
-  | frontend   | dev    | up to date | 0      | today        |
-  | shared-lib | main   | up to date | 0      | today        |
+  | Submodule  | Tracks | Status     | Behind |
+  |------------|--------|------------|--------|
+  | backend    | dev    | stale      | 5      |
+  | frontend   | dev    | up to date | 0      |
+  | shared-lib | main   | up to date | 0      |
 
 Branch Config:
   | Submodule  | .gitmodules branch | Status |
@@ -146,7 +76,7 @@ Dependency Overlap:
   | Package   | backend | frontend | Aligned? |
   |-----------|---------|----------|----------|
   | pydantic  | 2.9.0   | -        | n/a      |
-  | requests  | 2.32.0  | -        | n/a      |
+  | boto3     | 1.35.0  | 1.34.0   | NO       |
 
 Standards Compliance:
   | Check       | backend | frontend | infra |
@@ -154,14 +84,18 @@ Standards Compliance:
   | pre-commit  | OK      | OK       | MISS  |
   | editorconfig| OK      | OK       | OK    |
   | CI          | OK      | OK       | OK    |
-
-Recommendations:
-  1. Update stale pointers: /ai-mono-sync
-  2. Set tracked branch for shared-lib: git config -f .gitmodules submodule.shared-lib.branch main
-  3. Add pre-commit to infra: cd infra && /ai-standardize-precommit
 ```
 
+## 4. Prioritized Recommendations
+
+Merge CLI `recommendations` with dependency analysis findings. Order by urgency:
+
+1. **Failing standards** (missing pre-commit, CI): suggest specific skills (e.g., "Add pre-commit to infra: `cd infra && /ai-standardize-precommit`")
+2. **Stale pointers**: suggest `/ai-mono-sync`
+3. **Missing branch config**: suggest `git config -f .gitmodules submodule.<name>.branch <branch>`
+4. **Dependency mismatches**: flag which packages are out of alignment and suggest updating
+
 ## Error Handling
-- **Not a monorepo**: Clear error
+- **Not a monorepo**: CLI exits with error -- relay the message
 - **Submodule not initialized**: Suggest `/ai-mono-init`
-- **No dependency files found**: Skip dependency analysis for that submodule
+- **No dependency files found**: Skip dependency analysis for that submodule, note in output

--- a/src/ai_shell/templates/claude/skills/ai-mono-init/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-init/SKILL.md
@@ -1,106 +1,68 @@
 ---
 name: ai-mono-init
 description: First-time monorepo development setup. Initializes submodules and verifies environment. Use when setting up a monorepo for development or saying 'set up this monorepo'.
-argument-hint: ""
+argument-hint: "[--submodule <name>]"
 ---
 
 Set up this monorepo for development: $ARGUMENTS
 
-Initializes all submodules, verifies tracked branches are configured in `.gitmodules`, checks .env files, and guides the user through per-submodule AI tool setup.
+Initializes all submodules, verifies tracked branches are configured in `.gitmodules`, checks .env files, and guides per-submodule AI tool setup.
 
 ## Usage Examples
 - `/ai-mono-init` - Full first-time setup
+- `/ai-mono-init --submodule backend` - Check one submodule only
 
-## 1. Verify Monorepo
-
-```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
-```
-
-## 2. Initialize Submodules
+## 1. Run Init
 
 ```bash
-git submodule update --init --recursive
+ai-mono init --json $ARGUMENTS
 ```
 
-Report which submodules were initialized.
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-## 3. Verify Tracked Branches
+**JSON response:**
+```json
+{
+  "submodules": [
+    {"name": "str", "tracked_branch": "str", "branch_configured": true, "env_status": "ok|missing|no_template"}
+  ],
+  "warnings": ["str"],
+  "deps_installed": true
+}
+```
 
-Each submodule should have a `branch` configured in `.gitmodules` so that `/ai-mono-sync` knows which branch to track. IaC repos with a dev-to-main workflow should track `dev`; library repos should track `main`.
+## 2. Configure Unconfigured Branches
 
+For each submodule where `branch_configured` is false, look inside the submodule directory to detect its type, then suggest the correct tracked branch:
+
+- **IaC / backend / web service**: has `*.tf` files, `Dockerfile`, `docker-compose.yml`, `serverless.yml`, or deployment configs → suggest tracking `dev` (these use a dev-to-main promotion workflow)
+- **Library / package**: has `pyproject.toml` with `[build-system]`, or `package.json` with a `main` field → suggest tracking `main` (libraries release directly from main)
+- **Unknown**: ask the user which branch this submodule releases from
+
+Explain to the user in plain terms: "The tracked branch tells the monorepo which branch to follow for updates. Backend services typically use 'dev' because changes go through staging first. Libraries use 'main' because they publish directly."
+
+Set the branch:
 ```bash
-NEEDS_BRANCH_CONFIG=()
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    BRANCH=$(git config -f .gitmodules "submodule.${SUBMODULE}.branch" 2>/dev/null)
-    if [ -z "$BRANCH" ]; then
-        NEEDS_BRANCH_CONFIG+=("$SUBMODULE")
-        echo "[WARN] $SUBMODULE: no branch set in .gitmodules"
-    else
-        echo "[OK] $SUBMODULE: tracks $BRANCH"
-    fi
-done
+git config -f .gitmodules submodule.<name>.branch <branch>
 ```
 
-If any submodules are missing branch config, guide the user:
-
-```
-The following submodules have no tracked branch in .gitmodules:
-  - frontend
-  - shared-lib
-
-Set the branch each submodule should track:
-  - IaC repos (dev-to-main workflow): git config -f .gitmodules submodule.frontend.branch dev
-  - Library repos (main-only):        git config -f .gitmodules submodule.shared-lib.branch main
-
-Then commit the change:
-  git add .gitmodules && git commit -m "chore: set tracked branches for submodules"
-```
-
-Ask the user which branch each unconfigured submodule should track, then run the `git config -f .gitmodules` commands and commit.
-
-## 4. Verify Environment Files
-
-For each submodule, check for `.env`:
-
+After setting all branches, stage and commit:
 ```bash
-for SUBMODULE in $(git submodule status | awk '{print $2}'); do
-    if [ -f "$SUBMODULE/.env" ]; then
-        echo "[OK] $SUBMODULE/.env exists"
-    elif [ -f "$SUBMODULE/.env.example" ]; then
-        echo "[WARN] $SUBMODULE/.env missing -- copy from .env.example:"
-        echo "  cp $SUBMODULE/.env.example $SUBMODULE/.env"
-    else
-        echo "[WARN] $SUBMODULE has no .env or .env.example"
-    fi
-done
+git add .gitmodules
+git commit -m "chore: set tracked branches for submodules"
 ```
 
-Also check the monorepo root:
-```bash
-if [ -f ".env" ]; then
-    echo "[OK] Monorepo root .env exists"
-elif [ -f ".env.example" ]; then
-    echo "[WARN] Root .env missing -- copy from .env.example"
-else
-    echo "[INFO] No .env at monorepo root (may not be needed)"
-fi
-```
+## 3. Fix Environment Files
 
-## 5. Check Dev Dependencies
+For each submodule where `env_status` is:
+- `missing` (has .env.example but no .env): `cp <submodule>/.env.example <submodule>/.env`
+- `no_template`: note that no .env may be needed, or ask the user
 
-If the monorepo root has a `pyproject.toml`:
-```bash
-if [ -f "pyproject.toml" ]; then
-    echo "Installing monorepo dev dependencies..."
-    uv sync
-fi
-```
+Also check root .env if warnings mention it.
 
-## 6. Report Setup Status
+## 4. Report Setup Status
+
+Format results as:
 
 ```
 Monorepo setup complete!
@@ -124,7 +86,13 @@ Next steps:
   3. Check monorepo status: /ai-mono-status
 ```
 
+Use the repo type detection from step 2 to suggest `--iac` vs `--lib` for each submodule:
+- `--iac` for backends, web services, and infrastructure (repos that deploy)
+- `--lib` for libraries and packages (repos that publish)
+
+This is a one-time setup. After init, use `/ai-mono-status` for ongoing monitoring.
+
 ## Error Handling
-- **Not a monorepo**: Clear error
-- **Submodule clone fails**: Report which submodule failed, suggest checking SSH keys / access
-- **uv not available**: Skip dependency install, suggest installing uv
+- **Not a monorepo**: CLI exits with error -- relay the message
+- **Submodule clone fails**: Suggest checking SSH keys / access
+- **Specified submodule not found**: CLI exits with error -- relay and list available submodules

--- a/src/ai_shell/templates/claude/skills/ai-mono-status/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-status/SKILL.md
@@ -12,82 +12,36 @@ Provides a unified view of work happening across all submodules: open PRs, pipel
 - `/ai-mono-status` - Full status across all submodules
 - `/ai-mono-status --submodule backend` - Status for one submodule only
 
-## 1. Detect Submodules
+## 1. Get Status Data
 
 ```bash
-# Verify this is a monorepo (has .gitmodules)
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    echo "Run this command from the monorepo root directory."
-    exit 1
-fi
-
-git submodule status --recursive
+ai-mono status --json $ARGUMENTS
 ```
 
-Parse each submodule: name, current SHA, path.
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-## 2. Resolve Tracked Branch Per Submodule
-
-Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
-
-```bash
-# Read the tracked branch from .gitmodules (falls back to remote HEAD, then "main")
-tracked_branch_for() {
-    local sub="$1"
-    # 1. Check .gitmodules branch setting
-    local branch
-    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    # 2. Fall back to the submodule's remote HEAD
-    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    # 3. Default to main
-    echo "main"
+**JSON response:**
+```json
+{
+  "submodules": [
+    {
+      "name": "str",
+      "tracked_branch": "str",
+      "pointer_sha": "full SHA",
+      "remote_sha": "full SHA or null",
+      "behind": 0,
+      "open_prs": 0,
+      "ci_status": "passing|failing|unknown"
+    }
+  ],
+  "summary": {"total": 0, "stale": 0, "up_to_date": 0},
+  "recommendations": ["str"]
 }
 ```
 
-## 3. Per-Submodule Status
+## 2. Format Dashboard
 
-For each submodule:
-
-```bash
-SUBMODULE="backend"  # example
-TRACKED=$(tracked_branch_for "$SUBMODULE")
-
-# Current pointer vs tracked branch HEAD
-POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
-cd "$SUBMODULE"
-git fetch --all --prune 2>/dev/null
-
-REMOTE_SHA=$(git rev-parse "origin/$TRACKED" 2>/dev/null)
-
-# Commits behind
-if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
-    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" 2>/dev/null | wc -l)
-    echo "$SUBMODULE: $BEHIND commits behind origin/$TRACKED"
-else
-    echo "$SUBMODULE: up to date (tracking $TRACKED)"
-fi
-
-# Open PRs
-gh pr list --state open --json number,title,author,updatedAt --limit 5
-
-# Latest CI run
-gh run list --limit 1 --json status,conclusion,name,createdAt
-
-cd ..
-```
-
-## 4. Aggregated Dashboard
-
-Format output as a table:
+Present results as a table:
 
 ```
 Monorepo Status
@@ -105,17 +59,27 @@ Summary:
   - 2 submodules with stale pointers
 ```
 
-## 5. Suggested Next Actions
+Use the first 7 characters of pointer_sha for display.
 
-Based on status, suggest:
+## 3. AI Analysis
+
+Go beyond the CLI's raw data:
+
+- **Priority ordering**: Which submodule needs attention most urgently? Failing CI > stale pointers > open PRs needing review.
+- **Cross-referencing**: Do any open PRs correspond to stale pointers? (e.g., a merged PR in a submodule that hasn't been synced yet)
+- **Blocked work detection**: Are stale pointers blocking other submodules' work?
+
+## 4. Suggested Next Actions
+
+Based on status, suggest specific actions:
 - If submodules are behind: "Run `/ai-mono-sync` to update pointers"
 - If CI is failing: "Check frontend: `cd frontend && /ai-monitor-pipeline`"
 - If PRs need review: List them with links
-- If a submodule has no `branch` set in `.gitmodules`: "Consider setting tracked branch: `git config -f .gitmodules submodule.backend.branch dev`"
 - If everything is clean: "All submodules are up to date. No action needed."
 
+Include the CLI's `recommendations` array but enhance with skill-specific suggestions.
+
 ## Error Handling
-- **Not a monorepo**: Clear error pointing to monorepo root
-- **Submodule not initialized**: Suggest `git submodule update --init`
-- **No GitHub remote**: Skip PR/CI checks for that submodule, warn
-- **Rate limiting**: Warn and show partial results
+- **Not a monorepo**: CLI exits with error -- relay the message
+- **Submodule not initialized**: Suggest `/ai-mono-init`
+- **No GitHub remote / gh CLI missing**: CLI warns and returns `open_prs: 0`, `ci_status: "unknown"` -- note this in output

--- a/src/ai_shell/templates/claude/skills/ai-mono-sync/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-mono-sync/SKILL.md
@@ -8,108 +8,71 @@ Sync submodule pointers to their latest tracked branch HEAD: $ARGUMENTS
 
 Updates submodule pointers to the latest commit on each submodule's tracked branch (configured in `.gitmodules`), optionally staging and committing the pointer changes.
 
+Sync after PRs are merged in a submodule, not while feature branches are in progress. Syncing picks up whatever is on the tracked branch (typically `dev` or `main`).
+
 ## Usage Examples
 - `/ai-mono-sync` - Show what would change (dry run)
 - `/ai-mono-sync --commit` - Update pointers and commit changes
 - `/ai-mono-sync --submodule backend` - Sync only one submodule
 
-## 1. Verify Monorepo
+## 1. Preview Changes
 
 ```bash
-if [ ! -f .gitmodules ]; then
-    echo "ERROR: No .gitmodules found. This does not appear to be a monorepo."
-    exit 1
-fi
+ai-mono sync --json $ARGUMENTS
 ```
 
-## 2. Resolve Tracked Branch Per Submodule
+If `ai-mono` is not found, install it: `uv sync --all-extras`, then retry.
 
-Each submodule tracks a specific branch configured in `.gitmodules`. IaC repos with a dev-to-main workflow should track `dev`; library repos track `main`.
+If `--commit` was passed in $ARGUMENTS, skip to step 3.
 
-```bash
-tracked_branch_for() {
-    local sub="$1"
-    local branch
-    branch=$(git config -f .gitmodules "submodule.${sub}.branch" 2>/dev/null)
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    branch=$(cd "$sub" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-    if [ -n "$branch" ]; then
-        echo "$branch"
-        return
-    fi
-    echo "main"
+**JSON response:**
+```json
+{
+  "submodules": [
+    {
+      "name": "str",
+      "tracked_branch": "str",
+      "pointer_sha": "full SHA",
+      "remote_sha": "full SHA or null",
+      "behind": 0,
+      "updated": false
+    }
+  ],
+  "committed": false,
+  "commit_sha": null
 }
 ```
 
-## 3. Fetch All Submodules
+## 2. Show Changes and Ask for Confirmation
 
-```bash
-git submodule update --init --recursive
-git submodule foreach git fetch --all --prune
-```
-
-## 4. Check Each Submodule
-
-For each submodule, compare the current pointer with the tracked branch HEAD:
-
-```bash
-SUBMODULE="backend"
-TRACKED=$(tracked_branch_for "$SUBMODULE")
-POINTER_SHA=$(git submodule status "$SUBMODULE" | awk '{print $1}' | tr -d '+\-U')
-
-cd "$SUBMODULE"
-REMOTE_SHA=$(git rev-parse "origin/$TRACKED")
-
-if [ "$POINTER_SHA" != "$REMOTE_SHA" ]; then
-    BEHIND=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" | wc -l)
-    NEW_COMMITS=$(git log --oneline "$POINTER_SHA..$REMOTE_SHA" --limit 5)
-    echo "$SUBMODULE ($TRACKED): $BEHIND new commits"
-    echo "$NEW_COMMITS"
-fi
-cd ..
-```
-
-## 5. Show Changes Before Acting
-
-Display a summary of what would change:
+Display what would change:
 
 ```
 Submodule pointer updates:
-  backend  (tracks dev):   a1b2c3d -> x9y8z7w  (3 commits)
-  frontend (tracks dev):   d4e5f6g -> d4e5f6g  (up to date)
+  backend  (tracks dev):    a1b2c3d -> x9y8z7w  (3 commits)
+  frontend (tracks dev):    d4e5f6g -> d4e5f6g  (up to date)
   shared-lib (tracks main): h7i8j9k -> m3n4o5p  (1 commit)
 ```
 
-If `--commit` was NOT passed, stop here and ask: "Apply these changes? Run `/ai-mono-sync --commit` to update and commit."
+If any submodule is >20 commits behind, warn: "backend is 47 commits behind -- consider reviewing changes before syncing."
 
-## 6. Update Pointers
+If no submodules need updating: "All submodules are up to date. No action needed." Stop here.
 
-```bash
-# For each submodule that needs updating
-TRACKED=$(tracked_branch_for "$SUBMODULE")
-cd "$SUBMODULE"
-git checkout "$TRACKED"
-git pull origin "$TRACKED"
-cd ..
-```
+Otherwise, ask: "Apply these changes? Run `/ai-mono-sync --commit` to update and commit."
 
-## 7. Stage and Commit
+## 3. Apply Changes
+
+When `--commit` is in $ARGUMENTS (or user confirms):
 
 ```bash
-# Stage submodule pointer changes
-git add backend shared-lib  # only changed submodules
-
-# Build commit message listing what changed
-git commit -m "chore(deps): update submodule pointers
-
-- backend (dev): a1b2c3d -> x9y8z7w (3 commits)
-- shared-lib (main): h7i8j9k -> m3n4o5p (1 commit)"
+ai-mono sync --commit --json [--submodule "$NAME"]
 ```
 
-## 8. Final Output
+The CLI handles: fetching, updating pointers, staging, and committing with a `chore(deps): update submodule pointers` message listing each updated submodule.
+
+## 4. Report Results
+
+Parse the JSON response. If `committed` is true:
 
 ```
 Submodule pointers updated and committed.
@@ -120,13 +83,14 @@ Updated:
 Unchanged:
   - frontend (dev)
 
-Commit: chore(deps): update submodule pointers
+Commit: <commit_sha>
 Next: git push or /ai-submit-work
 ```
 
+If `committed` is false but updates were expected, warn that something went wrong.
+
 ## Error Handling
-- **Not a monorepo**: Clear error
-- **Submodule has local changes**: Warn and skip that submodule
-- **Submodule in detached HEAD**: Re-attach to tracked branch before updating
+- **Not a monorepo**: CLI exits with error -- relay the message
+- **Submodule has local changes**: CLI may fail to update -- warn and suggest stashing
 - **No changes**: Exit cleanly with "All submodules are up to date"
-- **No branch configured in .gitmodules**: Warn and fall back to remote HEAD or main
+- **Specified submodule not found**: CLI exits with error -- relay and list available submodules

--- a/src/ai_shell/templates/notes-monorepo.md
+++ b/src/ai_shell/templates/notes-monorepo.md
@@ -65,14 +65,15 @@ These are independent -- ai-shell loads `.env` from the current working director
 
 ## Monorepo Coordination Tools
 
-This monorepo uses `augint-mono` for coordination across submodules:
+This monorepo uses `ai-mono` for coordination across submodules:
 
 ```bash
-uv run augint-mono status    # Cross-repo status dashboard
-uv run augint-mono sync      # Update submodule pointers
-uv run augint-mono init      # First-time dev setup
-uv run augint-mono health    # Cross-repo health analysis
-uv run augint-mono foreach   # Run command in each submodule
+uv run ai-mono status    # Cross-repo status dashboard
+uv run ai-mono sync      # Update submodule pointers
+uv run ai-mono init      # First-time dev setup
+uv run ai-mono health    # Cross-repo health analysis
+uv run ai-mono foreach   # Run command in each submodule
+# All commands support: --json (structured output), -s/--submodule <name> (filter)
 ```
 
 ## Conventions
@@ -83,11 +84,63 @@ uv run augint-mono foreach   # Run command in each submodule
 
 ## Development Workflow
 
-1. **Check status**: `/ai-mono-status` -- see what is happening across all repos
-2. **Sync pointers**: `/ai-mono-sync` -- ensure submodule pointers are current
-3. **Pick work**: Identify which submodule needs attention, `cd` into it
-4. **Develop**: Follow that submodule's own workflow (pick issue, prepare branch, develop, submit)
-5. **Update pointers**: Return to monorepo root, `/ai-mono-sync` to capture new commits
+1. **First-time setup** (once): `/ai-mono-init` -- initializes submodules, verifies branch config and .env files
+2. **Check status**: `/ai-mono-status` -- see what is happening across all repos
+3. **Sync pointers**: `/ai-mono-sync` -- ensure submodule pointers are current
+4. **Pick work**: Identify which submodule needs attention, `cd` into it
+5. **Develop**: Follow that submodule's own workflow (pick issue, prepare branch, develop, submit)
+6. **Update pointers**: Return to monorepo root, `/ai-mono-sync` to capture merged work
+
+Only sync pointers after PRs are merged in the submodule. Syncing while feature branches are in progress can cause confusion.
+
+## Key Concepts
+
+When explaining submodule state to users, use plain language:
+
+- **Submodule pointer**: the monorepo records which exact version (commit) of each submodule it uses. "Stale pointer" means the submodule has newer work that hasn't been picked up yet.
+- **Tracked branch**: the branch in each submodule that the monorepo follows for updates (configured in `.gitmodules`). IaC/backend repos typically track `dev`; libraries track `main`.
+- **Syncing**: updating the monorepo to use the latest version of each submodule's tracked branch.
+
+## Common Problems and Recovery
+
+### Accidental pointer change
+If `git status` shows an unexpected submodule change you didn't intend:
+```bash
+git restore <submodule-path>    # Undo the pointer change
+```
+
+### Submodule shows "modified content" or merge conflicts
+You (or the AI agent) edited files inside a submodule from the monorepo root. Fix by working inside the submodule:
+```bash
+cd <submodule>
+git status                      # See what changed
+git stash                       # Or commit/discard as appropriate
+cd ..
+```
+
+### Submodule not initialized or missing
+```bash
+/ai-mono-init                   # Re-initializes all submodules
+```
+
+### Pointer sync fails due to local changes in submodule
+```bash
+cd <submodule>
+git stash                       # Save local work
+cd ..
+/ai-mono-sync --commit          # Now sync will succeed
+cd <submodule>
+git stash pop                   # Restore local work
+```
+
+## Batch Operations vs Manual Work
+
+Use `/ai-mono-foreach` for **read-only checks** across all submodules:
+- `git status`, `uv run pytest`, dependency audits, standards checks
+
+Use **manual `cd` into each submodule** for **development work**:
+- Code changes, dependency updates, branch management, PR creation
+- The "no cross-boundary edits" rule means development always happens inside a submodule
 
 ## Architecture
 

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -766,7 +766,7 @@ class TestNotesTemplateSelection:
         )
         content = (tmp_path / "NOTES.md").read_text()
         assert "## Submodule Map" in content
-        assert "augint-mono" in content
+        assert "ai-mono" in content
 
     def test_none_type_uses_default_notes(self, tmp_path):
         scaffold_project(tmp_path, repo_type=None)

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "augint-github"
-version = "1.3.5"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -22,9 +22,22 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/a4/fde29e2f2046ec8a3dcff470b384340669639cff29105015055f62f26810/augint_github-1.3.5.tar.gz", hash = "sha256:3f2f684dbdd3db1d24117e8f631be7bd97c6b784497437427a50ee7b0a8f82a7", size = 4732, upload-time = "2026-04-04T06:55:03.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/15/9f38002c3b0853bcb11d804e73d6d0ef04f992fb26bc067d739783a3424b/augint_github-1.4.0.tar.gz", hash = "sha256:858a804da657bb47dc716e544b18ea34056189167844e481e12c642ddc59380d", size = 13965, upload-time = "2026-04-05T03:13:53.661Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/3c/cf19410b451dd369c09aed87d8c03a79336738803e2912473326459e2d34/augint_github-1.3.5-py3-none-any.whl", hash = "sha256:fbd0a81c2129a5cfdd8dd9cacc626b9c059ec4cb54878777fd179fbd13f2dcca", size = 4714, upload-time = "2026-04-04T06:55:02.145Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0d/63742dcd61d7fc282b4313b4e6d9168e9befddcaeb761998542cf68caccc/augint_github-1.4.0-py3-none-any.whl", hash = "sha256:a3bb9e2b08d5cdb41e374482efe64996d7ae8a9c26c2d94ca42639e15bb1c615", size = 21841, upload-time = "2026-04-05T03:13:52.522Z" },
+]
+
+[[package]]
+name = "augint-mono"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/4b/0087a47b04c52ef3858d3c3c8a96f6ebdc9e123813c10450e676159d0e59/augint_mono-0.1.3.tar.gz", hash = "sha256:f8dcda57001ca32e741bed1be2b47d9e5664bd09a1ec63a753765d676241319e", size = 8384, upload-time = "2026-04-05T03:50:05.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/ad/2ad0719bbfe062859ca2c8080e0ea5a838fc32ebeda61a353f05496ad90f/augint_mono-0.1.3-py3-none-any.whl", hash = "sha256:05eaf69b2bcecf3b173e550d2ad5e78e3b9f6a0749ef54ad4ad909f987b35133", size = 13217, upload-time = "2026-04-05T03:50:04.351Z" },
 ]
 
 [[package]]
@@ -56,6 +69,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "augint-github" },
+    { name = "augint-mono" },
 ]
 
 [package.metadata]
@@ -79,7 +93,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "augint-github", specifier = ">=1.3.1" }]
+dev = [
+    { name = "augint-github", specifier = ">=1.3.1" },
+    { name = "augint-mono", specifier = ">=0.1.2" },
+]
 
 [[package]]
 name = "bandit"


### PR DESCRIPTION
## Summary

- Rewrite all 5 ai-mono-* skill templates to call `ai-mono <cmd> --json` instead of reimplementing submodule logic in bash prose (closes #22)
- Add non-developer guidance: Key Concepts glossary, Common Problems recovery, Batch vs Manual decision guide in notes-monorepo.md
- Add `ai-mono` permission to settings.json template
- Fix CLI command name throughout: use `ai-mono` (entry point) not `augint-mono` (package name)
- Also includes prior branch work: CLAUDE.md bootstrap on update, merge commit defaults, rebase deny rule cleanup

## Test plan

- [x] `uv run pytest tests/unit/test_scaffold.py` -- 98 passed
- [x] `uv run pre-commit run --all-files` -- all passed
- [x] All 5 claude/agents skill pairs verified identical
- [x] Zero remaining `augint-mono` CLI references in templates
- [x] Zero remaining `tracked_branch_for()` references in templates