### PR TITLE
fix(docker): set core.filemode false in container git config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -207,6 +207,8 @@ RUN git config --global --add safe.directory '*' && \
     git config --global color.ui auto && \
     git config --global core.editor vim && \
     git config --global init.defaultBranch main && \
+    # Ignore file permission changes on drvfs/9p-mounted Windows filesystems
+    git config --global core.filemode false && \
     # Disable git hooks in container - AI tools commit frequently; pre-commit is run explicitly
     git config --global core.hooksPath /dev/null && \
     git config --global --unset-all http.sslbackend || true


### PR DESCRIPTION
## Summary
- Adds `git config --global core.filemode false` to the Dockerfile's git config block
- Prevents git from tracking spurious 100644->100755 permission changes on drvfs/9p-mounted Windows filesystems

## Checks run locally
- [x] Pre-commit hooks
- [x] Security scan (bandit + pip-audit)
- [x] License compliance
- [x] Unit tests with coverage (245 passed, 95%)

## Issue
Closes #17