### PR TITLE
feat(scaffold): add ai-fix-repo-standards skill for GitHub repo remediation

### DIFF
--- a/.claude/skills/ai-fix-repo-standards/SKILL.md
+++ b/.claude/skills/ai-fix-repo-standards/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: ai-fix-repo-standards
+description: "Audit and fix GitHub repository standards (rulesets, pipelines, auto-merge) using ai-gh. Use when repos drift from standard config, or saying 'fix repo standards'."
+argument-hint: "[--dry-run] [--status-only]"
+---
+
+Audit and remediate GitHub repository standards using ai-gh: $ARGUMENTS
+
+> **Workflow automation:** This skill is part of an automated workflow. It makes autonomous decisions for safe, reversible fixes (enabling auto-merge, applying rulesets). For destructive operations (regenerating pipelines), it shows a diff and asks for confirmation.
+
+Detects repo type (IaC vs library), runs `ai-gh status` to identify mismatches in rulesets, pipelines, and settings, then applies targeted fixes for each failure. Re-verifies after fixes and reports results.
+
+## Usage Examples
+
+```bash
+/ai-fix-repo-standards                # Full audit + fix cycle
+/ai-fix-repo-standards --status-only  # Audit only, no fixes
+/ai-fix-repo-standards --dry-run      # Show what would be fixed without applying
+```
+
+## Prerequisites
+
+The `ai-gh` CLI (from `augint-github`) must be installed and a `.env` file must exist in the repo root with:
+
+```
+GH_REPO=repository-name
+GH_ACCOUNT=github-account-or-org
+GH_TOKEN=personal-access-token
+```
+
+Check prerequisites before proceeding:
+
+```bash
+# Verify ai-gh is available
+command -v ai-gh >/dev/null 2>&1 || { echo "ERROR: ai-gh not found. Install augint-github first."; exit 1; }
+
+# Verify .env exists with required keys
+if [ ! -f ".env" ]; then
+    echo "ERROR: No .env file found. Create one with GH_REPO, GH_ACCOUNT, GH_TOKEN."
+    exit 1
+fi
+for key in GH_REPO GH_ACCOUNT GH_TOKEN; do
+    grep -q "^${key}=" .env || echo "WARNING: $key not found in .env"
+done
+```
+
+If prerequisites fail, stop and tell the user what is missing.
+
+## 1. Detect Repo Type
+
+Auto-detect whether this is an IaC or library repo. The `ai-gh` CLI does this internally, but we need the type for targeted fixes.
+
+```bash
+# Check for IaC indicators
+REPO_TYPE="library"
+for indicator in template.yaml template.yml samconfig.toml cdk.json main.tf; do
+    if [ -f "$indicator" ]; then
+        REPO_TYPE="iac"
+        break
+    fi
+done
+
+# Check pipeline content as fallback
+if [ -f ".github/workflows/pipeline.yaml" ]; then
+    if grep -qiE "sam|cdk|terraform" .github/workflows/pipeline.yaml 2>/dev/null; then
+        REPO_TYPE="iac"
+    fi
+fi
+
+# Check for dev branch (IaC repos typically have one)
+DEV_BRANCH=""
+for candidate in dev develop staging; do
+    if git show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+        DEV_BRANCH=$candidate
+        break
+    fi
+done
+[ -n "$DEV_BRANCH" ] && REPO_TYPE="iac"
+```
+
+Report: "Detected repo type: **$REPO_TYPE**"
+
+## 2. Run Audit
+
+Run `ai-gh status` to get the full audit report:
+
+```bash
+ai-gh status --type $REPO_TYPE --verbose
+```
+
+Capture the output. The status command reports checks in a table with PASS/FAIL/WARN status:
+
+- **Auto-merge**: whether auto-merge is enabled on the repo
+- **Rulesets**: whether rulesets match the expected template (iac or library)
+- **Pipeline file**: whether `.github/workflows/pipeline.yaml` exists
+- **Status checks alignment**: whether ruleset-required checks match actual pipeline job names
+
+If `$ARGUMENTS` contains `--status-only`, display the audit results and stop here. Do not apply any fixes.
+
+## 3. Parse Failures and Plan Fixes
+
+For each FAIL or WARN result, determine the remediation action:
+
+| Failure | Remediation Command | Risk Level |
+|---------|---------------------|------------|
+| Auto-merge disabled | `ai-gh config --auto-merge` | Safe (reversible) |
+| Missing rulesets | `ai-gh rulesets --apply $REPO_TYPE` | Safe (additive) |
+| Ruleset drift (wrong checks, enforcement, bypass) | `ai-gh rulesets --apply $REPO_TYPE` | Medium (overwrites rulesets) |
+| Pipeline file missing | `ai-gh workflow --type $REPO_TYPE` | Medium (creates new file) |
+| Status check mismatch (pipeline vs ruleset) | Regenerate pipeline and/or reapply rulesets | High (overwrites pipeline) |
+
+If `$ARGUMENTS` contains `--dry-run`, show the planned fixes in a table and stop. Do not execute any commands.
+
+```
+=== Planned Fixes ===
+
+| # | Issue | Action | Risk |
+|---|-------|--------|------|
+| 1 | Auto-merge disabled | ai-gh config --auto-merge | Safe |
+| 2 | Missing rulesets | ai-gh rulesets --apply library | Safe |
+| 3 | Pipeline missing | ai-gh workflow --type library | Medium |
+```
+
+## 4. Apply Fixes
+
+Apply fixes in order from safest to most impactful:
+
+### Step 1: Enable auto-merge (if failed)
+
+```bash
+ai-gh config --auto-merge
+```
+
+This is always safe and reversible. Apply without confirmation.
+
+### Step 2: Apply rulesets (if missing or drifted)
+
+```bash
+ai-gh rulesets --apply $REPO_TYPE
+```
+
+This overwrites existing rulesets to match the template. Apply without confirmation for missing rulesets. For drifted rulesets, show the current vs expected state and apply (ruleset templates are the source of truth).
+
+### Step 3: Generate pipeline (if missing)
+
+```bash
+# If pipeline.yaml does not exist at all
+ai-gh workflow --type $REPO_TYPE
+```
+
+If the pipeline file already exists but has a status check mismatch, this is more complex:
+
+```bash
+# Preview what would change
+ai-gh workflow --type $REPO_TYPE --dry-run > /tmp/new-pipeline.yaml
+diff .github/workflows/pipeline.yaml /tmp/new-pipeline.yaml
+```
+
+**If the pipeline exists and needs updating**: Show the diff to the user and ask for confirmation before overwriting. The user may have custom pipeline steps that should be preserved.
+
+```bash
+# Only after user confirms
+ai-gh workflow --type $REPO_TYPE --force
+```
+
+### Step 4: Resolve status check mismatches
+
+If rulesets require checks that don't exist in the pipeline (or vice versa), this was likely fixed by steps 2-3 above. If mismatches remain after applying rulesets and pipeline:
+
+1. Show the specific mismatch (which checks are in rulesets but not pipeline, and vice versa)
+2. Flag for manual attention -- the user needs to either:
+   - Add the missing pipeline jobs, or
+   - Remove the extra ruleset checks
+3. Do NOT auto-fix complex mismatches -- they often indicate intentional customization
+
+## 5. Re-verify
+
+Run the audit again to confirm fixes took effect:
+
+```bash
+ai-gh status --type $REPO_TYPE --verbose
+```
+
+## 6. Report Results
+
+```
+=== Remediation Report ===
+
+Repo: $GH_ACCOUNT/$GH_REPO
+Type: $REPO_TYPE
+
+| Check | Before | After | Action Taken |
+|-------|--------|-------|-------------|
+| Auto-merge | FAIL | PASS | Enabled via ai-gh config |
+| Rulesets | FAIL | PASS | Applied $REPO_TYPE template |
+| Pipeline | PASS | PASS | No change needed |
+| Status checks | WARN | WARN | Manual attention needed |
+
+Fixed: X of Y issues
+Remaining: Z issues requiring manual intervention
+
+Manual action needed:
+  - Status check "build-validation" is in rulesets but has no matching pipeline job.
+    This is expected for IaC repos -- add a build-validation step to your pipeline
+    or remove it from the ruleset if not needed.
+```
+
+If all checks pass, end with: "All checks passing. Repository is in compliance."
+
+If issues remain, list each one with a brief explanation of why it could not be auto-fixed and what the user should do.
+
+## Error Handling
+
+- **ai-gh not installed**: Abort with install instructions (`pip install augint-github` or `uv add augint-github`)
+- **Missing .env**: Abort with template showing required keys
+- **GitHub API errors (401/403)**: Token is invalid or lacks permissions. Tell user to check GH_TOKEN has `repo` and `admin:org` scopes.
+- **Rate limiting**: Wait and retry once. If still failing, report and suggest trying later.
+- **Partial failure**: If some fixes succeed and others fail, report what worked and what did not. Do not roll back successful fixes.
+- **Unknown repo type**: Default to library. Warn the user to verify with `--type iac` if this is an IaC repo.

--- a/.claude/skills/ai-pick-issue/SKILL.md
+++ b/.claude/skills/ai-pick-issue/SKILL.md
@@ -114,7 +114,42 @@ if body_length > 500: score += 2  # Well-documented
 
 # CRITICAL: Never recommend closed issues
 if state == "CLOSED": score = -1000
+
+# Renovate Dependency Dashboard filtering (see subsection below)
+if is_renovate_dashboard(issue):
+    if not has_actionable_items(issue):
+        score = -1000  # Skip -- schedule handles it
+    else:
+        score = 6  # Override with moderate score for actionable dashboards
 ```
+
+### Renovate Dependency Dashboard Filtering
+
+Renovate creates a "Dependency Dashboard" issue that tracks all pending updates. Most of the time this issue requires no human intervention -- the Renovate schedule handles everything automatically. Only surface it when there are genuinely stuck or failed items.
+
+**Detection**: An issue is a Renovate dashboard if:
+- Title contains "Dependency Dashboard" (case-insensitive), OR
+- Author/creator is `renovate[bot]`
+
+**Triage the dashboard body** for actionable items. Fetch the full issue body:
+```bash
+gh issue view $NUMBER --json number,title,body,author
+```
+
+**Actionable** (include in recommendations):
+- Any item with a warning or error icon (`:warning:`, `:x:`, unicode warning/error symbols)
+- A "Rate-Limited" section with items stuck for >7 days
+- PRs listed under "Open" that are older than 14 days (stale/stuck)
+- Items explicitly marked as "Failing" or "Error"
+- Checkboxes the user has manually ticked (indicating manual intervention requested)
+
+**Not actionable** (exclude from recommendations):
+- Dashboard body says "all updates are up-to-date" or equivalent
+- Only contains "Detected Dependencies" section (informational)
+- All pending items are within their scheduled window
+- Open PRs are recent (<7 days) and progressing normally (awaiting CI or automerge)
+
+When a Renovate dashboard IS actionable, present it with a brief summary of what needs attention (e.g., "2 stuck PRs, 1 failed update") rather than showing the full dashboard body.
 
 ### Present Recommendations
 

--- a/src/ai_shell/scaffold.py
+++ b/src/ai_shell/scaffold.py
@@ -174,6 +174,7 @@ _UNIVERSAL_SKILLS = [
     "ai-standardize-precommit",
     "ai-standardize-dotfiles",
     "ai-standardize-repo",
+    "ai-fix-repo-standards",
 ]
 
 _RELEASE_SKILLS = ["ai-standardize-renovate", "ai-standardize-release"]
@@ -244,6 +245,7 @@ CLAUDE_SKILL_DIRS = [
     "ai-standardize-dotfiles",
     "ai-standardize-repo",
     "ai-setup-oidc",
+    "ai-fix-repo-standards",
 ]
 
 

--- a/src/ai_shell/templates/agents/skills/ai-fix-repo-standards/SKILL.md
+++ b/src/ai_shell/templates/agents/skills/ai-fix-repo-standards/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: ai-fix-repo-standards
+description: "Audit and fix GitHub repository standards (rulesets, pipelines, auto-merge) using ai-gh. Use when repos drift from standard config, or saying 'fix repo standards'."
+argument-hint: "[--dry-run] [--status-only]"
+---
+
+Audit and remediate GitHub repository standards using ai-gh: $ARGUMENTS
+
+> **Workflow automation:** This skill is part of an automated workflow. It makes autonomous decisions for safe, reversible fixes (enabling auto-merge, applying rulesets). For destructive operations (regenerating pipelines), it shows a diff and asks for confirmation.
+
+Detects repo type (IaC vs library), runs `ai-gh status` to identify mismatches in rulesets, pipelines, and settings, then applies targeted fixes for each failure. Re-verifies after fixes and reports results.
+
+## Usage Examples
+
+```bash
+/ai-fix-repo-standards                # Full audit + fix cycle
+/ai-fix-repo-standards --status-only  # Audit only, no fixes
+/ai-fix-repo-standards --dry-run      # Show what would be fixed without applying
+```
+
+## Prerequisites
+
+The `ai-gh` CLI (from `augint-github`) must be installed and a `.env` file must exist in the repo root with:
+
+```
+GH_REPO=repository-name
+GH_ACCOUNT=github-account-or-org
+GH_TOKEN=personal-access-token
+```
+
+Check prerequisites before proceeding:
+
+```bash
+# Verify ai-gh is available
+command -v ai-gh >/dev/null 2>&1 || { echo "ERROR: ai-gh not found. Install augint-github first."; exit 1; }
+
+# Verify .env exists with required keys
+if [ ! -f ".env" ]; then
+    echo "ERROR: No .env file found. Create one with GH_REPO, GH_ACCOUNT, GH_TOKEN."
+    exit 1
+fi
+for key in GH_REPO GH_ACCOUNT GH_TOKEN; do
+    grep -q "^${key}=" .env || echo "WARNING: $key not found in .env"
+done
+```
+
+If prerequisites fail, stop and tell the user what is missing.
+
+## 1. Detect Repo Type
+
+Auto-detect whether this is an IaC or library repo. The `ai-gh` CLI does this internally, but we need the type for targeted fixes.
+
+```bash
+# Check for IaC indicators
+REPO_TYPE="library"
+for indicator in template.yaml template.yml samconfig.toml cdk.json main.tf; do
+    if [ -f "$indicator" ]; then
+        REPO_TYPE="iac"
+        break
+    fi
+done
+
+# Check pipeline content as fallback
+if [ -f ".github/workflows/pipeline.yaml" ]; then
+    if grep -qiE "sam|cdk|terraform" .github/workflows/pipeline.yaml 2>/dev/null; then
+        REPO_TYPE="iac"
+    fi
+fi
+
+# Check for dev branch (IaC repos typically have one)
+DEV_BRANCH=""
+for candidate in dev develop staging; do
+    if git show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+        DEV_BRANCH=$candidate
+        break
+    fi
+done
+[ -n "$DEV_BRANCH" ] && REPO_TYPE="iac"
+```
+
+Report: "Detected repo type: **$REPO_TYPE**"
+
+## 2. Run Audit
+
+Run `ai-gh status` to get the full audit report:
+
+```bash
+ai-gh status --type $REPO_TYPE --verbose
+```
+
+Capture the output. The status command reports checks in a table with PASS/FAIL/WARN status:
+
+- **Auto-merge**: whether auto-merge is enabled on the repo
+- **Rulesets**: whether rulesets match the expected template (iac or library)
+- **Pipeline file**: whether `.github/workflows/pipeline.yaml` exists
+- **Status checks alignment**: whether ruleset-required checks match actual pipeline job names
+
+If `$ARGUMENTS` contains `--status-only`, display the audit results and stop here. Do not apply any fixes.
+
+## 3. Parse Failures and Plan Fixes
+
+For each FAIL or WARN result, determine the remediation action:
+
+| Failure | Remediation Command | Risk Level |
+|---------|---------------------|------------|
+| Auto-merge disabled | `ai-gh config --auto-merge` | Safe (reversible) |
+| Missing rulesets | `ai-gh rulesets --apply $REPO_TYPE` | Safe (additive) |
+| Ruleset drift (wrong checks, enforcement, bypass) | `ai-gh rulesets --apply $REPO_TYPE` | Medium (overwrites rulesets) |
+| Pipeline file missing | `ai-gh workflow --type $REPO_TYPE` | Medium (creates new file) |
+| Status check mismatch (pipeline vs ruleset) | Regenerate pipeline and/or reapply rulesets | High (overwrites pipeline) |
+
+If `$ARGUMENTS` contains `--dry-run`, show the planned fixes in a table and stop. Do not execute any commands.
+
+```
+=== Planned Fixes ===
+
+| # | Issue | Action | Risk |
+|---|-------|--------|------|
+| 1 | Auto-merge disabled | ai-gh config --auto-merge | Safe |
+| 2 | Missing rulesets | ai-gh rulesets --apply library | Safe |
+| 3 | Pipeline missing | ai-gh workflow --type library | Medium |
+```
+
+## 4. Apply Fixes
+
+Apply fixes in order from safest to most impactful:
+
+### Step 1: Enable auto-merge (if failed)
+
+```bash
+ai-gh config --auto-merge
+```
+
+This is always safe and reversible. Apply without confirmation.
+
+### Step 2: Apply rulesets (if missing or drifted)
+
+```bash
+ai-gh rulesets --apply $REPO_TYPE
+```
+
+This overwrites existing rulesets to match the template. Apply without confirmation for missing rulesets. For drifted rulesets, show the current vs expected state and apply (ruleset templates are the source of truth).
+
+### Step 3: Generate pipeline (if missing)
+
+```bash
+# If pipeline.yaml does not exist at all
+ai-gh workflow --type $REPO_TYPE
+```
+
+If the pipeline file already exists but has a status check mismatch, this is more complex:
+
+```bash
+# Preview what would change
+ai-gh workflow --type $REPO_TYPE --dry-run > /tmp/new-pipeline.yaml
+diff .github/workflows/pipeline.yaml /tmp/new-pipeline.yaml
+```
+
+**If the pipeline exists and needs updating**: Show the diff to the user and ask for confirmation before overwriting. The user may have custom pipeline steps that should be preserved.
+
+```bash
+# Only after user confirms
+ai-gh workflow --type $REPO_TYPE --force
+```
+
+### Step 4: Resolve status check mismatches
+
+If rulesets require checks that don't exist in the pipeline (or vice versa), this was likely fixed by steps 2-3 above. If mismatches remain after applying rulesets and pipeline:
+
+1. Show the specific mismatch (which checks are in rulesets but not pipeline, and vice versa)
+2. Flag for manual attention -- the user needs to either:
+   - Add the missing pipeline jobs, or
+   - Remove the extra ruleset checks
+3. Do NOT auto-fix complex mismatches -- they often indicate intentional customization
+
+## 5. Re-verify
+
+Run the audit again to confirm fixes took effect:
+
+```bash
+ai-gh status --type $REPO_TYPE --verbose
+```
+
+## 6. Report Results
+
+```
+=== Remediation Report ===
+
+Repo: $GH_ACCOUNT/$GH_REPO
+Type: $REPO_TYPE
+
+| Check | Before | After | Action Taken |
+|-------|--------|-------|-------------|
+| Auto-merge | FAIL | PASS | Enabled via ai-gh config |
+| Rulesets | FAIL | PASS | Applied $REPO_TYPE template |
+| Pipeline | PASS | PASS | No change needed |
+| Status checks | WARN | WARN | Manual attention needed |
+
+Fixed: X of Y issues
+Remaining: Z issues requiring manual intervention
+
+Manual action needed:
+  - Status check "build-validation" is in rulesets but has no matching pipeline job.
+    This is expected for IaC repos -- add a build-validation step to your pipeline
+    or remove it from the ruleset if not needed.
+```
+
+If all checks pass, end with: "All checks passing. Repository is in compliance."
+
+If issues remain, list each one with a brief explanation of why it could not be auto-fixed and what the user should do.
+
+## Error Handling
+
+- **ai-gh not installed**: Abort with install instructions (`pip install augint-github` or `uv add augint-github`)
+- **Missing .env**: Abort with template showing required keys
+- **GitHub API errors (401/403)**: Token is invalid or lacks permissions. Tell user to check GH_TOKEN has `repo` and `admin:org` scopes.
+- **Rate limiting**: Wait and retry once. If still failing, report and suggest trying later.
+- **Partial failure**: If some fixes succeed and others fail, report what worked and what did not. Do not roll back successful fixes.
+- **Unknown repo type**: Default to library. Warn the user to verify with `--type iac` if this is an IaC repo.

--- a/src/ai_shell/templates/claude/skills/ai-fix-repo-standards/SKILL.md
+++ b/src/ai_shell/templates/claude/skills/ai-fix-repo-standards/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: ai-fix-repo-standards
+description: "Audit and fix GitHub repository standards (rulesets, pipelines, auto-merge) using ai-gh. Use when repos drift from standard config, or saying 'fix repo standards'."
+argument-hint: "[--dry-run] [--status-only]"
+---
+
+Audit and remediate GitHub repository standards using ai-gh: $ARGUMENTS
+
+> **Workflow automation:** This skill is part of an automated workflow. It makes autonomous decisions for safe, reversible fixes (enabling auto-merge, applying rulesets). For destructive operations (regenerating pipelines), it shows a diff and asks for confirmation.
+
+Detects repo type (IaC vs library), runs `ai-gh status` to identify mismatches in rulesets, pipelines, and settings, then applies targeted fixes for each failure. Re-verifies after fixes and reports results.
+
+## Usage Examples
+
+```bash
+/ai-fix-repo-standards                # Full audit + fix cycle
+/ai-fix-repo-standards --status-only  # Audit only, no fixes
+/ai-fix-repo-standards --dry-run      # Show what would be fixed without applying
+```
+
+## Prerequisites
+
+The `ai-gh` CLI (from `augint-github`) must be installed and a `.env` file must exist in the repo root with:
+
+```
+GH_REPO=repository-name
+GH_ACCOUNT=github-account-or-org
+GH_TOKEN=personal-access-token
+```
+
+Check prerequisites before proceeding:
+
+```bash
+# Verify ai-gh is available
+command -v ai-gh >/dev/null 2>&1 || { echo "ERROR: ai-gh not found. Install augint-github first."; exit 1; }
+
+# Verify .env exists with required keys
+if [ ! -f ".env" ]; then
+    echo "ERROR: No .env file found. Create one with GH_REPO, GH_ACCOUNT, GH_TOKEN."
+    exit 1
+fi
+for key in GH_REPO GH_ACCOUNT GH_TOKEN; do
+    grep -q "^${key}=" .env || echo "WARNING: $key not found in .env"
+done
+```
+
+If prerequisites fail, stop and tell the user what is missing.
+
+## 1. Detect Repo Type
+
+Auto-detect whether this is an IaC or library repo. The `ai-gh` CLI does this internally, but we need the type for targeted fixes.
+
+```bash
+# Check for IaC indicators
+REPO_TYPE="library"
+for indicator in template.yaml template.yml samconfig.toml cdk.json main.tf; do
+    if [ -f "$indicator" ]; then
+        REPO_TYPE="iac"
+        break
+    fi
+done
+
+# Check pipeline content as fallback
+if [ -f ".github/workflows/pipeline.yaml" ]; then
+    if grep -qiE "sam|cdk|terraform" .github/workflows/pipeline.yaml 2>/dev/null; then
+        REPO_TYPE="iac"
+    fi
+fi
+
+# Check for dev branch (IaC repos typically have one)
+DEV_BRANCH=""
+for candidate in dev develop staging; do
+    if git show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+        DEV_BRANCH=$candidate
+        break
+    fi
+done
+[ -n "$DEV_BRANCH" ] && REPO_TYPE="iac"
+```
+
+Report: "Detected repo type: **$REPO_TYPE**"
+
+## 2. Run Audit
+
+Run `ai-gh status` to get the full audit report:
+
+```bash
+ai-gh status --type $REPO_TYPE --verbose
+```
+
+Capture the output. The status command reports checks in a table with PASS/FAIL/WARN status:
+
+- **Auto-merge**: whether auto-merge is enabled on the repo
+- **Rulesets**: whether rulesets match the expected template (iac or library)
+- **Pipeline file**: whether `.github/workflows/pipeline.yaml` exists
+- **Status checks alignment**: whether ruleset-required checks match actual pipeline job names
+
+If `$ARGUMENTS` contains `--status-only`, display the audit results and stop here. Do not apply any fixes.
+
+## 3. Parse Failures and Plan Fixes
+
+For each FAIL or WARN result, determine the remediation action:
+
+| Failure | Remediation Command | Risk Level |
+|---------|---------------------|------------|
+| Auto-merge disabled | `ai-gh config --auto-merge` | Safe (reversible) |
+| Missing rulesets | `ai-gh rulesets --apply $REPO_TYPE` | Safe (additive) |
+| Ruleset drift (wrong checks, enforcement, bypass) | `ai-gh rulesets --apply $REPO_TYPE` | Medium (overwrites rulesets) |
+| Pipeline file missing | `ai-gh workflow --type $REPO_TYPE` | Medium (creates new file) |
+| Status check mismatch (pipeline vs ruleset) | Regenerate pipeline and/or reapply rulesets | High (overwrites pipeline) |
+
+If `$ARGUMENTS` contains `--dry-run`, show the planned fixes in a table and stop. Do not execute any commands.
+
+```
+=== Planned Fixes ===
+
+| # | Issue | Action | Risk |
+|---|-------|--------|------|
+| 1 | Auto-merge disabled | ai-gh config --auto-merge | Safe |
+| 2 | Missing rulesets | ai-gh rulesets --apply library | Safe |
+| 3 | Pipeline missing | ai-gh workflow --type library | Medium |
+```
+
+## 4. Apply Fixes
+
+Apply fixes in order from safest to most impactful:
+
+### Step 1: Enable auto-merge (if failed)
+
+```bash
+ai-gh config --auto-merge
+```
+
+This is always safe and reversible. Apply without confirmation.
+
+### Step 2: Apply rulesets (if missing or drifted)
+
+```bash
+ai-gh rulesets --apply $REPO_TYPE
+```
+
+This overwrites existing rulesets to match the template. Apply without confirmation for missing rulesets. For drifted rulesets, show the current vs expected state and apply (ruleset templates are the source of truth).
+
+### Step 3: Generate pipeline (if missing)
+
+```bash
+# If pipeline.yaml does not exist at all
+ai-gh workflow --type $REPO_TYPE
+```
+
+If the pipeline file already exists but has a status check mismatch, this is more complex:
+
+```bash
+# Preview what would change
+ai-gh workflow --type $REPO_TYPE --dry-run > /tmp/new-pipeline.yaml
+diff .github/workflows/pipeline.yaml /tmp/new-pipeline.yaml
+```
+
+**If the pipeline exists and needs updating**: Show the diff to the user and ask for confirmation before overwriting. The user may have custom pipeline steps that should be preserved.
+
+```bash
+# Only after user confirms
+ai-gh workflow --type $REPO_TYPE --force
+```
+
+### Step 4: Resolve status check mismatches
+
+If rulesets require checks that don't exist in the pipeline (or vice versa), this was likely fixed by steps 2-3 above. If mismatches remain after applying rulesets and pipeline:
+
+1. Show the specific mismatch (which checks are in rulesets but not pipeline, and vice versa)
+2. Flag for manual attention -- the user needs to either:
+   - Add the missing pipeline jobs, or
+   - Remove the extra ruleset checks
+3. Do NOT auto-fix complex mismatches -- they often indicate intentional customization
+
+## 5. Re-verify
+
+Run the audit again to confirm fixes took effect:
+
+```bash
+ai-gh status --type $REPO_TYPE --verbose
+```
+
+## 6. Report Results
+
+```
+=== Remediation Report ===
+
+Repo: $GH_ACCOUNT/$GH_REPO
+Type: $REPO_TYPE
+
+| Check | Before | After | Action Taken |
+|-------|--------|-------|-------------|
+| Auto-merge | FAIL | PASS | Enabled via ai-gh config |
+| Rulesets | FAIL | PASS | Applied $REPO_TYPE template |
+| Pipeline | PASS | PASS | No change needed |
+| Status checks | WARN | WARN | Manual attention needed |
+
+Fixed: X of Y issues
+Remaining: Z issues requiring manual intervention
+
+Manual action needed:
+  - Status check "build-validation" is in rulesets but has no matching pipeline job.
+    This is expected for IaC repos -- add a build-validation step to your pipeline
+    or remove it from the ruleset if not needed.
+```
+
+If all checks pass, end with: "All checks passing. Repository is in compliance."
+
+If issues remain, list each one with a brief explanation of why it could not be auto-fixed and what the user should do.
+
+## Error Handling
+
+- **ai-gh not installed**: Abort with install instructions (`pip install augint-github` or `uv add augint-github`)
+- **Missing .env**: Abort with template showing required keys
+- **GitHub API errors (401/403)**: Token is invalid or lacks permissions. Tell user to check GH_TOKEN has `repo` and `admin:org` scopes.
+- **Rate limiting**: Wait and retry once. If still failing, report and suggest trying later.
+- **Partial failure**: If some fixes succeed and others fail, report what worked and what did not. Do not roll back successful fixes.
+- **Unknown repo type**: Default to library. Warn the user to verify with `--type iac` if this is an IaC repo.

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "augint-github"
-version = "1.4.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -22,22 +22,22 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/15/9f38002c3b0853bcb11d804e73d6d0ef04f992fb26bc067d739783a3424b/augint_github-1.4.0.tar.gz", hash = "sha256:858a804da657bb47dc716e544b18ea34056189167844e481e12c642ddc59380d", size = 13965, upload-time = "2026-04-05T03:13:53.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/8a/09b09b2a83a08f8efd4b9dfbe61ec101b921303767bf6a6f14164a2327e2/augint_github-1.6.0.tar.gz", hash = "sha256:cbc425b9656405724fd538f0a48af7c3ade8bde672e3f8090c9397d1e5bd7fb2", size = 15477, upload-time = "2026-04-05T04:40:44.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/0d/63742dcd61d7fc282b4313b4e6d9168e9befddcaeb761998542cf68caccc/augint_github-1.4.0-py3-none-any.whl", hash = "sha256:a3bb9e2b08d5cdb41e374482efe64996d7ae8a9c26c2d94ca42639e15bb1c615", size = 21841, upload-time = "2026-04-05T03:13:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3e/2e7da9bffa73ba00c7c603ca4aff0eba9f3effae86d47b54c09fef675e22/augint_github-1.6.0-py3-none-any.whl", hash = "sha256:598db16bcd0490f67ed5630b6c21923e61604d416ced9295e9fd6302ec1fb632", size = 24301, upload-time = "2026-04-05T04:40:43.224Z" },
 ]
 
 [[package]]
 name = "augint-mono"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/4b/0087a47b04c52ef3858d3c3c8a96f6ebdc9e123813c10450e676159d0e59/augint_mono-0.1.3.tar.gz", hash = "sha256:f8dcda57001ca32e741bed1be2b47d9e5664bd09a1ec63a753765d676241319e", size = 8384, upload-time = "2026-04-05T03:50:05.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/b2/bab7b3594e62dd2f65fac5621176ee7183a8d518ac4981439a3e66177497/augint_mono-0.1.4.tar.gz", hash = "sha256:617727f5d9f01de4ae56d135d519c19441ef4af3c9a8d3cbac3f8b78e1394386", size = 8640, upload-time = "2026-04-05T03:59:09.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/ad/2ad0719bbfe062859ca2c8080e0ea5a838fc32ebeda61a353f05496ad90f/augint_mono-0.1.3-py3-none-any.whl", hash = "sha256:05eaf69b2bcecf3b173e550d2ad5e78e3b9f6a0749ef54ad4ad909f987b35133", size = 13217, upload-time = "2026-04-05T03:50:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/99/55516a9a17d0899d1dfbefc0e869f619f19e573769d144bb0c694c5e52d4/augint_mono-0.1.4-py3-none-any.whl", hash = "sha256:52ebb37bcb721b0cbf021fbde0da3b09e5a9fc15550de933d53f96ca7d7b1af2", size = 13508, upload-time = "2026-04-05T03:59:07.651Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `ai-fix-repo-standards` skill that uses `ai-gh` CLI to audit and fix GitHub repository standards (rulesets, pipelines, auto-merge)
- Skill detects repo type (IaC vs library), runs `ai-gh status`, applies targeted fixes in order of safety, re-verifies compliance, and reports results
- Registered in scaffold.py under `_UNIVERSAL_SKILLS` (available to all repo types)

## Checks run locally
- [x] Pre-commit hooks (all passed)
- [x] Unit tests with coverage (245 passed, 95% coverage)

## Issue
Closes #27