### PR TITLE
feat: add first-class Amazon Bedrock support

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -21,6 +21,17 @@
       "options": {
         "region": "{env:AWS_REGION}",
         "profile": "{env:AWS_PROFILE}"
+      },
+      "models": {
+        "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+          "name": "Claude Sonnet 4 (Bedrock)"
+        },
+        "us.anthropic.claude-opus-4-20250514-v1:0": {
+          "name": "Claude Opus 4 (Bedrock)"
+        },
+        "us.anthropic.claude-haiku-4-20250514-v1:0": {
+          "name": "Claude Haiku 4 (Bedrock)"
+        }
       }
     }
   },

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
-from ai_shell.config import load_config
+from ai_shell.config import AiShellConfig, load_config
 from ai_shell.container import ContainerManager
 from ai_shell.defaults import build_dev_environment
 from ai_shell.scaffold import BranchStrategy, RepoType
@@ -104,19 +104,35 @@ def _resolve_repo_config(
     return None, None, "dev"
 
 
-def _get_manager(ctx) -> tuple[ContainerManager, str, dict[str, str]]:
+def _get_manager(
+    ctx,
+    *,
+    bedrock: bool = False,
+    bedrock_profile: str = "",
+) -> tuple[ContainerManager, str, dict[str, str], AiShellConfig]:
     """Create ContainerManager from Click context and ensure dev container.
 
-    Returns (manager, container_name, exec_env) where exec_env is a freshly
-    resolved environment dict from .env / host env, suitable for passing as
-    extra_env to exec/run calls so that token updates take effect immediately.
+    Returns (manager, container_name, exec_env, config) where exec_env is a
+    freshly resolved environment dict from .env / host env, suitable for passing
+    as extra_env to exec/run calls so that token updates take effect immediately.
+
+    When *bedrock* is True, ``CLAUDE_CODE_USE_BEDROCK=1`` is injected into
+    exec_env and *bedrock_profile* overrides ``AWS_PROFILE`` for the tool
+    process (the container-level env retains the infra profile).
     """
     project = ctx.obj.get("project") if ctx.obj else None
     config = load_config(project_override=project, project_dir=Path.cwd())
     manager = ContainerManager(config)
     container_name = manager.ensure_dev_container()
-    exec_env = build_dev_environment(config.extra_env, config.project_dir)
-    return manager, container_name, exec_env
+    exec_env = build_dev_environment(
+        config.extra_env,
+        config.project_dir,
+        bedrock=bedrock,
+        aws_profile=config.ai_profile,
+        aws_region=config.aws_region,
+        bedrock_profile=bedrock_profile or config.bedrock_profile,
+    )
+    return manager, container_name, exec_env, config
 
 
 @click.command()
@@ -156,13 +172,25 @@ def _get_manager(ctx) -> tuple[ContainerManager, str, dict[str, str]]:
     default=False,
     help="Skip merging notes into context file on --update/--reset.",
 )
+@click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
+@click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
 @click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
 @click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
 @click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def claude(
-    ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, repo_type_flag, extra_args
+    ctx,
+    do_init,
+    do_update,
+    do_reset,
+    do_clean,
+    safe,
+    skip_merge,
+    use_aws,
+    cli_profile,
+    repo_type_flag,
+    extra_args,
 ):
     """Launch Claude Code in the dev container."""
     if do_init or do_update or do_reset or do_clean:
@@ -187,7 +215,16 @@ def claude(
             merge_notes_into_context(Path.cwd(), "claude", background=True)
         return
 
-    manager, name, exec_env = _get_manager(ctx)
+    # Load config first to check provider setting
+    project = ctx.obj.get("project") if ctx.obj else None
+    config = load_config(project_override=project, project_dir=Path.cwd())
+    use_bedrock = use_aws or config.claude_provider == "aws"
+
+    manager, name, exec_env, config = _get_manager(
+        ctx,
+        bedrock=use_bedrock,
+        bedrock_profile=cli_profile or "",
+    )
 
     if safe:
         cmd = ["claude", *extra_args]
@@ -276,7 +313,7 @@ def codex(
             merge_notes_into_context(Path.cwd(), "codex", background=True)
         return
 
-    manager, name, exec_env = _get_manager(ctx)
+    manager, name, exec_env, _config = _get_manager(ctx)
     cmd = ["codex"]
     if not safe:
         cmd.extend(["--dangerously-bypass-approvals-and-sandbox"])
@@ -322,11 +359,24 @@ def codex(
     default=False,
     help="Skip merging notes into context file on --update/--reset.",
 )
+@click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
+@click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
 @click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
 @click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
 @click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
 @click.pass_context
-def opencode(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, repo_type_flag):
+def opencode(
+    ctx,
+    do_init,
+    do_update,
+    do_reset,
+    do_clean,
+    safe,
+    skip_merge,
+    use_aws,
+    cli_profile,
+    repo_type_flag,
+):
     """Launch opencode in the dev container."""
     if do_init or do_update or do_reset or do_clean:
         from ai_shell.scaffold import scaffold_opencode as _scaffold_opencode
@@ -350,7 +400,16 @@ def opencode(ctx, do_init, do_update, do_reset, do_clean, safe, skip_merge, repo
             merge_notes_into_context(Path.cwd(), "opencode", background=True)
         return
 
-    manager, name, exec_env = _get_manager(ctx)
+    # Load config first to check provider setting
+    project = ctx.obj.get("project") if ctx.obj else None
+    config = load_config(project_override=project, project_dir=Path.cwd())
+    use_bedrock = use_aws or config.opencode_provider == "aws"
+
+    manager, name, exec_env, config = _get_manager(
+        ctx,
+        bedrock=use_bedrock,
+        bedrock_profile=cli_profile or "",
+    )
     cmd = ["/root/.opencode/bin/opencode"]
     console.print(f"[bold]Launching opencode in {name}...[/bold]")
     manager.exec_interactive(name, cmd, extra_env=exec_env)
@@ -410,8 +469,7 @@ def aider(ctx, do_init, do_update, do_reset, do_clean, safe, repo_type_flag, ext
         )
         return
 
-    manager, name, exec_env = _get_manager(ctx)
-    config = manager.config
+    manager, name, exec_env, config = _get_manager(ctx)
     cmd = ["aider", "--model", config.aider_model]
     if not safe:
         cmd.append("--yes-always")
@@ -426,7 +484,7 @@ def aider(ctx, do_init, do_update, do_reset, do_clean, safe, repo_type_flag, ext
 @click.pass_context
 def shell(ctx):
     """Open a bash shell in the dev container."""
-    manager, name, exec_env = _get_manager(ctx)
+    manager, name, exec_env, _config = _get_manager(ctx)
     console.print(f"[bold]Opening shell in {name}...[/bold]")
     manager.exec_interactive(name, ["/bin/bash"], extra_env=exec_env)
 

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -50,6 +50,15 @@ class AiShellConfig:
     extra_volumes: list[str] = field(default_factory=list)
     extra_ports: list[int] = field(default_factory=list)
 
+    # AWS
+    ai_profile: str = ""  # AWS profile for infra (sets AWS_PROFILE in container)
+    aws_region: str = ""  # Override AWS_REGION
+    bedrock_profile: str = ""  # AWS profile for Bedrock LLM API calls
+
+    # Per-tool provider
+    claude_provider: str = ""  # "anthropic" (default) or "aws"
+    opencode_provider: str = ""  # "ollama" (default) or "aws"
+
     # Project workflow
     repo_type: str | None = None  # "library" | "iac" | "monorepo"
     branch_strategy: str | None = None  # "main" | "dev"
@@ -147,6 +156,25 @@ def _apply_toml(config: AiShellConfig, path: Path) -> None:
     if "model" in aider:
         config.aider_model = aider["model"]
 
+    # [aws] section
+    aws = data.get("aws", {})
+    if "ai_profile" in aws:
+        config.ai_profile = aws["ai_profile"]
+    if "region" in aws:
+        config.aws_region = aws["region"]
+    if "bedrock_profile" in aws:
+        config.bedrock_profile = aws["bedrock_profile"]
+
+    # [claude] section
+    claude_sec = data.get("claude", {})
+    if "provider" in claude_sec:
+        config.claude_provider = claude_sec["provider"]
+
+    # [opencode] section
+    opencode_sec = data.get("opencode", {})
+    if "provider" in opencode_sec:
+        config.opencode_provider = opencode_sec["provider"]
+
     # [project] section
     project = data.get("project", {})
     if "repo_type" in project:
@@ -169,6 +197,11 @@ def _apply_env_vars(config: AiShellConfig) -> None:
         "AI_SHELL_OLLAMA_PORT": ("ollama_port", int),
         "AI_SHELL_WEBUI_PORT": ("webui_port", int),
         "AI_SHELL_AIDER_MODEL": ("aider_model", str),
+        "AI_SHELL_AI_PROFILE": ("ai_profile", str),
+        "AI_SHELL_AWS_REGION": ("aws_region", str),
+        "AI_SHELL_BEDROCK_PROFILE": ("bedrock_profile", str),
+        "AI_SHELL_CLAUDE_PROVIDER": ("claude_provider", str),
+        "AI_SHELL_OPENCODE_PROVIDER": ("opencode_provider", str),
     }
 
     for env_key, (attr, type_fn) in env_map.items():

--- a/src/ai_shell/container.py
+++ b/src/ai_shell/container.py
@@ -116,7 +116,12 @@ class ContainerManager:
     def _create_dev_container(self, name: str) -> Container:
         """Create the dev container with all docker-compose config."""
         mounts = build_dev_mounts(self.config.project_dir, self.config.project_name)
-        environment = build_dev_environment(self.config.extra_env, self.config.project_dir)
+        environment = build_dev_environment(
+            self.config.extra_env,
+            self.config.project_dir,
+            aws_profile=self.config.ai_profile,
+            aws_region=self.config.aws_region,
+        )
 
         # Add any extra volumes from config
         for vol_spec in self.config.extra_volumes:

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -43,6 +43,11 @@ DEFAULT_WEBUI_PORT = 3000
 DEFAULT_DEV_PORTS = [3000, 4200, 5000, 5173, 5678, 8000, 8080, 8888]
 
 # =============================================================================
+# Bedrock defaults
+# =============================================================================
+DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+# =============================================================================
 # Container names
 # =============================================================================
 OLLAMA_CONTAINER = "augint-shell-ollama"
@@ -144,6 +149,11 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
 def build_dev_environment(
     extra_env: dict[str, str] | None = None,
     project_dir: Path | None = None,
+    *,
+    bedrock: bool = False,
+    aws_profile: str = "",
+    aws_region: str = "",
+    bedrock_profile: str = "",
 ) -> dict[str, str]:
     """Build environment variables matching docker-compose.yml dev service.
 
@@ -151,6 +161,10 @@ def build_dev_environment(
     host environment variables and hardcoded defaults.
 
     Priority (highest wins): extra_env > .env file > os.environ > defaults.
+
+    When *bedrock* is True, ``CLAUDE_CODE_USE_BEDROCK=1`` is injected and
+    *bedrock_profile* (if set) overrides ``AWS_PROFILE`` so the LLM provider
+    authenticates with the correct AWS account.
     """
     from dotenv import dotenv_values
 
@@ -167,14 +181,19 @@ def build_dev_environment(
         return os.environ.get(key, default)
 
     env: dict[str, str] = {
-        "AWS_PROFILE": _resolve("AWS_PROFILE"),
-        "AWS_REGION": _resolve("AWS_REGION", "us-east-1"),
+        "AWS_PROFILE": aws_profile or _resolve("AWS_PROFILE"),
+        "AWS_REGION": aws_region or _resolve("AWS_REGION", "us-east-1"),
         "AWS_PAGER": "",
         "GH_TOKEN": _resolve("GH_TOKEN"),
         "GITHUB_TOKEN": _resolve("GH_TOKEN"),
         "HUSKY": "0",
         "IS_SANDBOX": "1",
     }
+
+    if bedrock:
+        env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        if bedrock_profile:
+            env["AWS_PROFILE"] = bedrock_profile
 
     if extra_env:
         env.update(extra_env)

--- a/src/ai_shell/templates/ai-shell.toml
+++ b/src/ai_shell/templates/ai-shell.toml
@@ -1,12 +1,101 @@
+# =============================================================================
 # ai-shell.toml - Project configuration for ai-shell
-# Uncomment and modify the settings you want to override.
-# See: https://github.com/svange/augint-shell
+# =============================================================================
+# Uncomment and modify settings you want to override.
+# Priority (highest wins): CLI flags > env vars > this file > global config > defaults
+# Global config: ~/.config/ai-shell/config.toml (same format, applies to all projects)
+# Docs: https://github.com/svange/augint-shell
 
+# =============================================================================
+# [project] - Repository classification and branching
+# =============================================================================
+# repo_type:
+#   "library"  - PyPI/npm packages, main-only branching
+#   "iac"      - Infrastructure repos, dev -> main promotion
+#   "monorepo" - Multiple packages in one repo
+#
+# branch_strategy:
+#   "main" - Feature branches merge directly to main (library pattern)
+#   "dev"  - Feature branches merge to dev, dev promotes to main (iac/web pattern)
+#
+# dev_branch: Name of the development branch (only used when branch_strategy = "dev")
+#
 # [project]
-# repo_type = "library"           # "library" | "iac" | "monorepo"
-# branch_strategy = "main"        # "main" | "dev"
-# dev_branch = "dev"              # only when branch_strategy = "dev"
+# repo_type = "library"
+# branch_strategy = "main"
+# dev_branch = "dev"
 
+# =============================================================================
+# [aws] - Amazon Web Services configuration
+# =============================================================================
+# ai_profile: AWS profile for the AI's working environment (aws cli, terraform,
+#   cdk). Sets AWS_PROFILE in the container. This is the account the AI uses
+#   when running infrastructure commands.
+#   Override with env var: AI_SHELL_AI_PROFILE
+#
+# bedrock_profile: AWS profile for Bedrock LLM API calls. Often a different
+#   account than ai_profile. Overrides AWS_PROFILE specifically for AI tool
+#   processes (Claude Code, opencode) when their provider is set to "aws".
+#   Override with env var: AI_SHELL_BEDROCK_PROFILE
+#   Override per-session with: --profile <name> on the CLI
+#
+# region: AWS region for Bedrock API calls. Default: us-east-1
+#   Override with env var: AI_SHELL_AWS_REGION
+#
+# Authentication: ~/.aws is bind-mounted into the container (read-write).
+# SSO, credential files, and config are available automatically.
+# If SSO tokens expire, run 'aws sso login --profile <name>' on the host.
+#
+# [aws]
+# ai_profile = "my-infra-account"
+# bedrock_profile = "my-ai-account"
+# region = "us-east-1"
+
+# =============================================================================
+# [claude] - Claude Code settings
+# =============================================================================
+# provider: API backend for Claude Code.
+#   "anthropic" - Direct Anthropic API (default, uses ~/.claude credentials)
+#   "aws"       - Amazon Bedrock (uses bedrock_profile from [aws] section)
+#
+# When provider = "aws":
+#   - CLAUDE_CODE_USE_BEDROCK=1 is set in the environment
+#   - AWS_PROFILE is set to bedrock_profile for Claude's process
+#   - Quick switch with CLI: ai-shell claude --aws
+#   - Override per-session:   ai-shell claude --aws --profile <name>
+#   - Tip: pin Bedrock model versions with ANTHROPIC_DEFAULT_SONNET_MODEL env var
+#
+# Override with env var: AI_SHELL_CLAUDE_PROVIDER
+#
+# [claude]
+# provider = "aws"
+
+# =============================================================================
+# [opencode] - opencode settings
+# =============================================================================
+# provider: API backend for opencode.
+#   "ollama" - Local Ollama LLM instance (default)
+#   "aws"    - Amazon Bedrock (uses bedrock_profile from [aws] section)
+#
+# When provider = "aws", use opencode's model picker to select a Bedrock model.
+# Pre-configured models: Claude Sonnet 4, Opus 4, Haiku 4.
+# Quick switch with CLI: ai-shell opencode --aws
+# Override per-session:   ai-shell opencode --aws --profile <name>
+#
+# Override with env var: AI_SHELL_OPENCODE_PROVIDER
+#
+# [opencode]
+# provider = "aws"
+
+# =============================================================================
+# [container] - Docker container settings
+# =============================================================================
+# image: Docker image (default: svange/augint-shell)
+# image_tag: Image tag (default: current ai-shell version)
+# extra_env: Additional environment variables for the container
+# extra_volumes: Additional bind mounts ("/host/path:/container/path" or ":/path:ro")
+# ports: Additional ports to expose (extends the default dev port set)
+#
 # [container]
 # image = "svange/augint-shell"
 # image_tag = "latest"
@@ -14,6 +103,15 @@
 # extra_volumes = ["/host/path:/container/path"]
 # ports = [9000, 9229]
 
+# =============================================================================
+# [llm] - Local LLM settings (Ollama + Open WebUI)
+# =============================================================================
+# primary_model: Default Ollama model for inference
+# fallback_model: Backup model if primary unavailable
+# context_size: Context window in tokens
+# ollama_port: Host port for Ollama API (default: 11434)
+# webui_port: Host port for Open WebUI (default: 3000)
+#
 # [llm]
 # primary_model = "qwen3.5:27b"
 # fallback_model = "qwen3-coder-next"
@@ -21,5 +119,10 @@
 # ollama_port = 11434
 # webui_port = 3000
 
+# =============================================================================
+# [aider] - Aider settings
+# =============================================================================
+# model: LLM model string (default: ollama_chat/<primary_model>)
+#
 # [aider]
 # model = "ollama_chat/qwen3.5:27b"

--- a/src/ai_shell/templates/opencode/opencode.json
+++ b/src/ai_shell/templates/opencode/opencode.json
@@ -21,6 +21,17 @@
       "options": {
         "region": "{env:AWS_REGION}",
         "profile": "{env:AWS_PROFILE}"
+      },
+      "models": {
+        "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+          "name": "Claude Sonnet 4 (Bedrock)"
+        },
+        "us.anthropic.claude-opus-4-20250514-v1:0": {
+          "name": "Claude Opus 4 (Bedrock)"
+        },
+        "us.anthropic.claude-haiku-4-20250514-v1:0": {
+          "name": "Claude Haiku 4 (Bedrock)"
+        }
       }
     }
   },

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -209,3 +209,102 @@ branch_strategy = "main"
         config = load_config(project_dir=tmp_path)
         assert config.repo_type == "monorepo"
         assert config.branch_strategy == "main"
+
+
+class TestAwsConfig:
+    def test_aws_defaults_empty(self, tmp_path):
+        config = load_config(project_dir=tmp_path)
+        assert config.ai_profile == ""
+        assert config.aws_region == ""
+        assert config.bedrock_profile == ""
+        assert config.claude_provider == ""
+        assert config.opencode_provider == ""
+
+    def test_ai_profile_from_toml(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[aws]
+ai_profile = "my-infra"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.ai_profile == "my-infra"
+
+    def test_bedrock_profile_from_toml(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[aws]
+bedrock_profile = "my-ai-account"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.bedrock_profile == "my-ai-account"
+
+    def test_aws_region_from_toml(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[aws]
+region = "eu-west-1"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.aws_region == "eu-west-1"
+
+    def test_claude_provider_from_toml(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[claude]
+provider = "aws"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.claude_provider == "aws"
+
+    def test_opencode_provider_from_toml(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[opencode]
+provider = "aws"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.opencode_provider == "aws"
+
+    def test_full_aws_config(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[aws]
+ai_profile = "infra-acct"
+bedrock_profile = "ai-acct"
+region = "us-west-2"
+
+[claude]
+provider = "aws"
+
+[opencode]
+provider = "aws"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.ai_profile == "infra-acct"
+        assert config.bedrock_profile == "ai-acct"
+        assert config.aws_region == "us-west-2"
+        assert config.claude_provider == "aws"
+        assert config.opencode_provider == "aws"
+
+    def test_provider_env_vars(self, tmp_path):
+        env = {
+            "AI_SHELL_CLAUDE_PROVIDER": "aws",
+            "AI_SHELL_OPENCODE_PROVIDER": "aws",
+        }
+        with patch.dict("os.environ", env):
+            config = load_config(project_dir=tmp_path)
+        assert config.claude_provider == "aws"
+        assert config.opencode_provider == "aws"
+
+    def test_bedrock_profile_env_var(self, tmp_path):
+        with patch.dict("os.environ", {"AI_SHELL_BEDROCK_PROFILE": "ai-acct"}):
+            config = load_config(project_dir=tmp_path)
+        assert config.bedrock_profile == "ai-acct"
+
+    def test_ai_profile_env_var(self, tmp_path):
+        with patch.dict("os.environ", {"AI_SHELL_AI_PROFILE": "infra-acct"}):
+            config = load_config(project_dir=tmp_path)
+        assert config.ai_profile == "infra-acct"
+
+    def test_env_overrides_toml(self, tmp_path):
+        (tmp_path / "ai-shell.toml").write_bytes(b"""
+[claude]
+provider = "anthropic"
+""")
+        with patch.dict("os.environ", {"AI_SHELL_CLAUDE_PROVIDER": "aws"}):
+            config = load_config(project_dir=tmp_path)
+        assert config.claude_provider == "aws"

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -190,3 +190,49 @@ class TestBuildDevEnvironmentDotenv:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path)
         assert env["AWS_REGION"] == "eu-west-1"
+
+
+class TestBuildDevEnvironmentBedrock:
+    def test_bedrock_adds_env_var(self):
+        env = build_dev_environment(bedrock=True)
+        assert env["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+    def test_no_bedrock_no_env_var(self):
+        env = build_dev_environment()
+        assert "CLAUDE_CODE_USE_BEDROCK" not in env
+
+    def test_bedrock_false_no_env_var(self):
+        env = build_dev_environment(bedrock=False)
+        assert "CLAUDE_CODE_USE_BEDROCK" not in env
+
+    def test_bedrock_profile_overrides_aws_profile(self):
+        with patch.dict("os.environ", {"AWS_PROFILE": "infra-acct"}, clear=True):
+            env = build_dev_environment(bedrock=True, bedrock_profile="ai-acct")
+        assert env["AWS_PROFILE"] == "ai-acct"
+        assert env["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+    def test_bedrock_without_bedrock_profile_keeps_aws_profile(self):
+        with patch.dict("os.environ", {"AWS_PROFILE": "infra-acct"}, clear=True):
+            env = build_dev_environment(bedrock=True)
+        assert env["AWS_PROFILE"] == "infra-acct"
+
+    def test_aws_profile_override(self):
+        with patch.dict("os.environ", {"AWS_PROFILE": "original"}, clear=True):
+            env = build_dev_environment(aws_profile="override")
+        assert env["AWS_PROFILE"] == "override"
+
+    def test_aws_region_override(self):
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(aws_region="eu-west-1")
+        assert env["AWS_REGION"] == "eu-west-1"
+
+    def test_aws_profile_empty_uses_resolved(self):
+        with patch.dict("os.environ", {"AWS_PROFILE": "from-env"}, clear=True):
+            env = build_dev_environment(aws_profile="")
+        assert env["AWS_PROFILE"] == "from-env"
+
+    def test_bedrock_profile_only_applies_when_bedrock_enabled(self):
+        with patch.dict("os.environ", {"AWS_PROFILE": "infra"}, clear=True):
+            env = build_dev_environment(bedrock=False, bedrock_profile="ai-acct")
+        assert env["AWS_PROFILE"] == "infra"
+        assert "CLAUDE_CODE_USE_BEDROCK" not in env

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -358,6 +358,14 @@ class TestScaffoldOpencode:
         assert bedrock["options"]["region"] == "{env:AWS_REGION}"
         assert bedrock["options"]["profile"] == "{env:AWS_PROFILE}"
 
+    def test_opencode_json_has_bedrock_models(self, tmp_path):
+        scaffold_opencode(tmp_path)
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        models = data["provider"]["amazon-bedrock"]["models"]
+        assert "us.anthropic.claude-sonnet-4-20250514-v1:0" in models
+        assert "us.anthropic.claude-opus-4-20250514-v1:0" in models
+        assert "us.anthropic.claude-haiku-4-20250514-v1:0" in models
+
     def test_opencode_json_has_instructions(self, tmp_path):
         scaffold_opencode(tmp_path)
         data = json.loads((tmp_path / "opencode.json").read_text())


### PR DESCRIPTION
## Summary

- Add per-tool `provider` config: `[claude] provider = "aws"` and `[opencode] provider = "aws"` in ai-shell.toml
- Add two-tier AWS profile support: `[aws] ai_profile` for infrastructure work, `[aws] bedrock_profile` for Bedrock LLM API calls
- Add `--aws` and `--profile` CLI flags on `claude` and `opencode` commands for quick session overrides
- When Bedrock enabled: inject `CLAUDE_CODE_USE_BEDROCK=1` and override `AWS_PROFILE` with `bedrock_profile` in per-tool exec env
- Populate opencode `amazon-bedrock` provider with Claude Sonnet 4, Opus 4, Haiku 4 model definitions
- Rewrite `ai-shell.toml` template as fully commented, self-documenting config reference
- Add 24 new tests covering config parsing, env var injection, and template validation

## Config example

```toml
[aws]
ai_profile = "my-infra-account"
bedrock_profile = "my-ai-account"
region = "us-east-1"

[claude]
provider = "aws"
```

## Test plan

- [x] 266 unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, yaml, etc.)
- [ ] CI pipeline passes
- [ ] Manual: `ai-shell claude --aws --profile <name>` injects correct env vars
- [ ] Manual: `ai-shell opencode --aws` shows Bedrock models in picker