### PR TITLE
feat(cli): add Bedrock diagnostics and user feedback

### DIFF
--- a/src/ai_shell/cli/__main__.py
+++ b/src/ai_shell/cli/__main__.py
@@ -1,5 +1,6 @@
 """ai-shell CLI entry point."""
 
+import logging
 import sys
 
 import click
@@ -13,11 +14,14 @@ from ai_shell.cli.commands.tools import aider, claude, codex, init, opencode, sh
 @click.group()
 @click.version_option(version=__version__, prog_name="ai-shell")
 @click.option("--project", default=None, help="Override project name for container naming.")
+@click.option("--verbose", "-v", is_flag=True, default=False, help="Enable debug logging.")
 @click.pass_context
-def cli(ctx, project):
+def cli(ctx, project, verbose):
     """AI Shell - Launch AI coding tools and local LLMs in Docker containers."""
     ctx.ensure_object(dict)
     ctx.obj["project"] = project
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
 
 
 # Tool subcommands

--- a/src/ai_shell/cli/commands/manage.py
+++ b/src/ai_shell/cli/commands/manage.py
@@ -1,4 +1,4 @@
-"""Container management commands: status, stop, clean, logs, pull."""
+"""Container management commands: status, stop, clean, logs, pull, env."""
 
 from pathlib import Path
 
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from ai_shell.config import load_config
 from ai_shell.container import ContainerManager
-from ai_shell.defaults import dev_container_name
+from ai_shell.defaults import build_dev_environment, dev_container_name
 from ai_shell.exceptions import ContainerNotFoundError
 
 console = Console(stderr=True)
@@ -100,3 +100,29 @@ def manage_pull(ctx):
     console.print(f"[bold]Pulling {image}...[/bold]")
     manager._pull_image_if_needed(image)
     console.print(f"[green]Image ready: {image}[/green]")
+
+
+@manage_group.command("env")
+@click.option("--aws", "use_aws", is_flag=True, default=False, help="Show Bedrock environment.")
+@click.pass_context
+def manage_env(ctx, use_aws):
+    """Show environment variables that would be passed to AI tool processes."""
+    project = ctx.obj.get("project") if ctx.obj else None
+    config = load_config(project_override=project, project_dir=Path.cwd())
+    use_bedrock = use_aws or config.claude_provider == "aws"
+
+    exec_env = build_dev_environment(
+        config.extra_env,
+        config.project_dir,
+        bedrock=use_bedrock,
+        aws_profile=config.ai_profile,
+        aws_region=config.aws_region,
+        bedrock_profile=config.bedrock_profile if use_bedrock else "",
+    )
+
+    console.print("[bold]Resolved exec environment:[/bold]")
+    for key in sorted(exec_env):
+        value = exec_env[key]
+        if key in ("GH_TOKEN", "GITHUB_TOKEN") and value:
+            value = value[:4] + "..." + value[-4:] if len(value) > 8 else "***"
+        console.print(f"  {key}={value}")

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -226,14 +226,21 @@ def claude(
         bedrock_profile=cli_profile or "",
     )
 
+    if use_bedrock:
+        profile_label = exec_env.get("AWS_PROFILE", "default")
+        region_label = exec_env.get("AWS_REGION", "us-east-1")
+        bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
+    else:
+        bedrock_label = ""
+
     if safe:
         cmd = ["claude", *extra_args]
-        console.print(f"[bold]Launching Claude Code (safe mode) in {name}...[/bold]")
+        console.print(f"[bold]Launching Claude Code (safe mode){bedrock_label} in {name}...[/bold]")
         manager.exec_interactive(name, cmd, extra_env=exec_env)
     else:
         # Try with -c first (continue previous conversation)
         cmd_continue = ["claude", "--dangerously-skip-permissions", "-c", *extra_args]
-        console.print(f"[bold]Launching Claude Code in {name}...[/bold]")
+        console.print(f"[bold]Launching Claude Code{bedrock_label} in {name}...[/bold]")
         exit_code, elapsed = manager.run_interactive(name, cmd_continue, extra_env=exec_env)
 
         if exit_code != 0 and elapsed < FAST_FAILURE_THRESHOLD:
@@ -410,8 +417,16 @@ def opencode(
         bedrock=use_bedrock,
         bedrock_profile=cli_profile or "",
     )
+
+    if use_bedrock:
+        profile_label = exec_env.get("AWS_PROFILE", "default")
+        region_label = exec_env.get("AWS_REGION", "us-east-1")
+        bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
+    else:
+        bedrock_label = ""
+
     cmd = ["/root/.opencode/bin/opencode"]
-    console.print(f"[bold]Launching opencode in {name}...[/bold]")
+    console.print(f"[bold]Launching opencode{bedrock_label} in {name}...[/bold]")
     manager.exec_interactive(name, cmd, extra_env=exec_env)
 
 

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -190,6 +190,9 @@ def build_dev_environment(
         "IS_SANDBOX": "1",
     }
 
+    # Mirror AWS_REGION to AWS_DEFAULT_REGION so both Node.js SDK paths resolve
+    env["AWS_DEFAULT_REGION"] = env["AWS_REGION"]
+
     if bedrock:
         env["CLAUDE_CODE_USE_BEDROCK"] = "1"
         if bedrock_profile:

--- a/tests/unit/test_cli_manage.py
+++ b/tests/unit/test_cli_manage.py
@@ -1,0 +1,78 @@
+"""Tests for CLI manage subcommands."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from ai_shell.cli.__main__ import cli
+
+
+@patch("ai_shell.cli.commands.manage.load_config")
+class TestManageEnv:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_manage_env_shows_variables(self, mock_config, tmp_path):
+        config = MagicMock()
+        config.claude_provider = ""
+        config.extra_env = {}
+        config.project_dir = tmp_path
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.bedrock_profile = ""
+        mock_config.return_value = config
+
+        result = self.runner.invoke(cli, ["manage", "env"])
+
+        assert result.exit_code == 0
+        assert "AWS_REGION" in result.output
+        assert "IS_SANDBOX" in result.output
+        assert "CLAUDE_CODE_USE_BEDROCK" not in result.output
+
+    def test_manage_env_with_aws_flag(self, mock_config, tmp_path):
+        config = MagicMock()
+        config.claude_provider = ""
+        config.extra_env = {}
+        config.project_dir = tmp_path
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.bedrock_profile = "rd"
+        mock_config.return_value = config
+
+        result = self.runner.invoke(cli, ["manage", "env", "--aws"])
+
+        assert result.exit_code == 0
+        assert "CLAUDE_CODE_USE_BEDROCK=1" in result.output
+        assert "AWS_PROFILE=rd" in result.output
+
+    def test_manage_env_config_provider_activates_bedrock(self, mock_config, tmp_path):
+        config = MagicMock()
+        config.claude_provider = "aws"
+        config.extra_env = {}
+        config.project_dir = tmp_path
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.bedrock_profile = "rd"
+        mock_config.return_value = config
+
+        result = self.runner.invoke(cli, ["manage", "env"])
+
+        assert result.exit_code == 0
+        assert "CLAUDE_CODE_USE_BEDROCK=1" in result.output
+
+    def test_manage_env_masks_tokens(self, mock_config, tmp_path):
+        config = MagicMock()
+        config.claude_provider = ""
+        config.extra_env = {}
+        config.project_dir = tmp_path
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.bedrock_profile = ""
+        mock_config.return_value = config
+
+        with patch.dict("os.environ", {"GH_TOKEN": "ghp_abcdefghijklmnop"}):
+            result = self.runner.invoke(cli, ["manage", "env"])
+
+        assert "ghp_abcdefghijklmnop" not in result.output
+        assert "ghp_" in result.output
+        assert "...mnop" in result.output

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -9,6 +9,7 @@ from ai_shell.cli.__main__ import cli
 TEST_EXEC_ENV = {
     "AWS_PROFILE": "",
     "AWS_REGION": "us-east-1",
+    "AWS_DEFAULT_REGION": "us-east-1",
     "AWS_PAGER": "",
     "GH_TOKEN": "test-token",
     "GITHUB_TOKEN": "test-token",
@@ -530,6 +531,50 @@ class TestToolCommands:
 
         mock_merge.assert_not_called()
         assert result.exit_code == 0
+
+    def test_claude_bedrock_launch_message(self, mock_config, mock_manager_cls, mock_build_env):
+        bedrock_env = dict(TEST_EXEC_ENV)
+        bedrock_env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        bedrock_env["AWS_PROFILE"] = "rd"
+        mock_build_env.return_value = bedrock_env
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.run_interactive.return_value = (0, 30.0)
+        mock_manager_cls.return_value = mock_manager
+
+        result = self.runner.invoke(cli, ["claude", "--aws"])
+
+        assert "Bedrock" in result.output
+        assert "profile=rd" in result.output
+        assert "region=us-east-1" in result.output
+
+    def test_claude_config_provider_activates_bedrock(
+        self, mock_config, mock_manager_cls, mock_build_env
+    ):
+        config = MagicMock()
+        config.claude_provider = "aws"
+        config.bedrock_profile = "rd"
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.extra_env = {}
+        config.project_dir = "/tmp/test"
+        mock_config.return_value = config
+
+        bedrock_env = dict(TEST_EXEC_ENV)
+        bedrock_env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        bedrock_env["AWS_PROFILE"] = "rd"
+        mock_build_env.return_value = bedrock_env
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.run_interactive.return_value = (0, 30.0)
+        mock_manager_cls.return_value = mock_manager
+
+        result = self.runner.invoke(cli, ["claude"])
+
+        assert "Bedrock" in result.output
+        mock_build_env.assert_called_once()
+        call_kwargs = mock_build_env.call_args[1]
+        assert call_kwargs["bedrock"] is True
 
     def test_version_flag(self, mock_config, mock_manager_cls, mock_build_env):
         result = self.runner.invoke(cli, ["--version"])

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -236,3 +236,15 @@ class TestBuildDevEnvironmentBedrock:
             env = build_dev_environment(bedrock=False, bedrock_profile="ai-acct")
         assert env["AWS_PROFILE"] == "infra"
         assert "CLAUDE_CODE_USE_BEDROCK" not in env
+
+    def test_aws_default_region_mirrors_aws_region(self):
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(aws_region="eu-west-1")
+        assert env["AWS_DEFAULT_REGION"] == "eu-west-1"
+        assert env["AWS_DEFAULT_REGION"] == env["AWS_REGION"]
+
+    def test_aws_default_region_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment()
+        assert env["AWS_DEFAULT_REGION"] == "us-east-1"
+        assert env["AWS_DEFAULT_REGION"] == env["AWS_REGION"]


### PR DESCRIPTION
## Summary
- Add visible Bedrock indicator to claude/opencode launch messages (profile + region)
- Add `AWS_DEFAULT_REGION` mirroring `AWS_REGION` for Node.js SDK compatibility
- Add `--verbose`/`-v` flag for debug logging across config, defaults, and container modules
- Add `manage env` subcommand for inspecting resolved environment variables with token masking

## Checks run locally
- [x] Pre-commit hooks (ruff, mypy, formatting)
- [x] Unit tests with coverage (278 passed, 95.56%)
- [x] Type checking (mypy clean)

## Testing
After upgrading:
- `ai-shell claude --aws` shows: `Launching Claude Code via Bedrock (profile=rd, region=us-east-1) in ...`
- `ai-shell manage env` shows resolved env vars
- `ai-shell manage env --aws` shows `CLAUDE_CODE_USE_BEDROCK=1`
- `ai-shell -v claude --aws` shows debug-level config and docker exec details