### PR TITLE
feat(cli): add --no-preflight flag to claude and opencode commands

### DIFF
--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -237,6 +237,13 @@ def _get_manager(
 )
 @click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
 @click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
+@click.option(
+    "--no-preflight",
+    "skip_preflight",
+    is_flag=True,
+    default=False,
+    help="Skip Bedrock pre-flight check (for debugging).",
+)
 @click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
 @click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
 @click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
@@ -252,6 +259,7 @@ def claude(
     skip_merge,
     use_aws,
     cli_profile,
+    skip_preflight,
     repo_type_flag,
     extra_args,
 ):
@@ -293,10 +301,11 @@ def claude(
         profile_label = exec_env.get("AWS_PROFILE", "default")
         region_label = exec_env.get("AWS_REGION", "us-east-1")
         bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
-        console.print(
-            f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
-        )
-        _check_bedrock_access(name, exec_env)
+        if not skip_preflight:
+            console.print(
+                f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
+            )
+            _check_bedrock_access(name, exec_env)
     else:
         bedrock_label = ""
 
@@ -435,6 +444,13 @@ def codex(
 )
 @click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
 @click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
+@click.option(
+    "--no-preflight",
+    "skip_preflight",
+    is_flag=True,
+    default=False,
+    help="Skip Bedrock pre-flight check (for debugging).",
+)
 @click.option("--lib", "--library", "repo_type_flag", flag_value="library", hidden=True)
 @click.option("--iac", "repo_type_flag", flag_value="iac", hidden=True)
 @click.option("--mono", "--monorepo", "repo_type_flag", flag_value="monorepo", hidden=True)
@@ -449,6 +465,7 @@ def opencode(
     skip_merge,
     use_aws,
     cli_profile,
+    skip_preflight,
     repo_type_flag,
 ):
     """Launch opencode in the dev container."""
@@ -489,10 +506,11 @@ def opencode(
         profile_label = exec_env.get("AWS_PROFILE", "default")
         region_label = exec_env.get("AWS_REGION", "us-east-1")
         bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
-        console.print(
-            f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
-        )
-        _check_bedrock_access(name, exec_env)
+        if not skip_preflight:
+            console.print(
+                f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
+            )
+            _check_bedrock_access(name, exec_env)
     else:
         bedrock_label = ""
 


### PR DESCRIPTION
## Summary

- Adds `--no-preflight` flag to both `ai-shell claude` and `ai-shell opencode`
- When set, skips the Bedrock `invoke-model` pre-flight check
- Useful for debugging Claude Code's own Bedrock routing without the check adding noise or ~5s latency

## Usage
```
ai-shell claude --aws --no-preflight
ai-shell opencode --aws --no-preflight
```

## Checks run locally
- [x] Pre-commit hooks
- [x] mypy
- [x] Unit tests (95.56% coverage)