### PR TITLE
feat(cli): auto-init config on first run, default to local provider

### DIFF
--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -286,6 +286,18 @@ def claude(
             merge_notes_into_context(Path.cwd(), "claude", background=True)
         return
 
+    # Auto-init if .claude/ is missing
+    if not (Path.cwd() / ".claude").exists():
+        console.print("[dim].claude/ not found - running first-time init...[/dim]")
+        from ai_shell.scaffold import scaffold_claude as _scaffold_claude
+
+        _auto_repo_type, _auto_branch, _auto_dev = _resolve_repo_config(None, Path.cwd())
+        _scaffold_claude(
+            Path.cwd(),
+            repo_type=_auto_repo_type,
+            branch_strategy=_auto_branch,
+        )
+
     # Load config first to check provider setting
     project = ctx.obj.get("project") if ctx.obj else None
     config = load_config(project_override=project, project_dir=Path.cwd())
@@ -396,6 +408,18 @@ def codex(
             merge_notes_into_context(Path.cwd(), "codex", background=True)
         return
 
+    # Auto-init if .codex/ is missing
+    if not (Path.cwd() / ".codex").exists():
+        console.print("[dim].codex/ not found - running first-time init...[/dim]")
+        from ai_shell.scaffold import scaffold_codex as _scaffold_codex
+
+        _auto_repo_type, _auto_branch, _auto_dev = _resolve_repo_config(None, Path.cwd())
+        _scaffold_codex(
+            Path.cwd(),
+            repo_type=_auto_repo_type,
+            branch_strategy=_auto_branch,
+        )
+
     manager, name, exec_env, _config = _get_manager(ctx)
     cmd = ["codex"]
     if not safe:
@@ -491,6 +515,18 @@ def opencode(
             merge_notes_into_context(Path.cwd(), "opencode", background=True)
         return
 
+    # Auto-init if opencode.json is missing
+    if not (Path.cwd() / "opencode.json").exists():
+        console.print("[dim]opencode.json not found - running first-time init...[/dim]")
+        from ai_shell.scaffold import scaffold_opencode as _scaffold_opencode
+
+        _auto_repo_type, _auto_branch, _auto_dev = _resolve_repo_config(None, Path.cwd())
+        _scaffold_opencode(
+            Path.cwd(),
+            repo_type=_auto_repo_type,
+            branch_strategy=_auto_branch,
+        )
+
     # Load config first to check provider setting
     project = ctx.obj.get("project") if ctx.obj else None
     config = load_config(project_override=project, project_dir=Path.cwd())
@@ -572,6 +608,17 @@ def aider(ctx, do_init, do_update, do_reset, do_clean, safe, repo_type_flag, ext
             repo_type=repo_type,
         )
         return
+
+    # Auto-init if .aider.conf.yml is missing
+    if not (Path.cwd() / ".aider.conf.yml").exists():
+        console.print("[dim].aider.conf.yml not found - running first-time init...[/dim]")
+        from ai_shell.scaffold import scaffold_aider as _scaffold_aider
+
+        _auto_repo_type, _auto_branch, _auto_dev = _resolve_repo_config(None, Path.cwd())
+        _scaffold_aider(
+            Path.cwd(),
+            repo_type=_auto_repo_type,
+        )
 
     manager, name, exec_env, config = _get_manager(ctx)
     cmd = ["aider", "--model", config.aider_model]

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -57,7 +57,7 @@ class AiShellConfig:
 
     # Per-tool provider
     claude_provider: str = ""  # "anthropic" (default) or "aws"
-    opencode_provider: str = ""  # "ollama" (default) or "aws"
+    opencode_provider: str = ""  # "local" (default, Ollama) or "aws" (Bedrock)
 
     # Project workflow
     repo_type: str | None = None  # "library" | "iac" | "monorepo"

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -35,8 +35,8 @@ WEBUI_DATA_VOLUME = "augint-shell-webui-data"
 # =============================================================================
 OLLAMA_IMAGE = "ollama/ollama"
 WEBUI_IMAGE = "ghcr.io/open-webui/open-webui:main"
-DEFAULT_PRIMARY_MODEL = "qwen3.5:27b"
-DEFAULT_FALLBACK_MODEL = "qwen3-coder-next"
+DEFAULT_PRIMARY_MODEL = "qwen3-coder-next"
+DEFAULT_FALLBACK_MODEL = "qwen3.5:27b"
 DEFAULT_CONTEXT_SIZE = 32768
 DEFAULT_OLLAMA_PORT = 11434
 DEFAULT_WEBUI_PORT = 3000

--- a/src/ai_shell/templates/ai-shell.toml
+++ b/src/ai_shell/templates/ai-shell.toml
@@ -74,8 +74,8 @@
 # [opencode] - opencode settings
 # =============================================================================
 # provider: API backend for opencode.
-#   "ollama" - Local Ollama LLM instance (default)
-#   "aws"    - Amazon Bedrock (uses bedrock_profile from [aws] section)
+#   "local" - Local Ollama LLM instance (default)
+#   "aws"   - Amazon Bedrock (uses bedrock_profile from [aws] section)
 #
 # When provider = "aws", use opencode's model picker to select a Bedrock model.
 # Pre-configured models: Claude Sonnet 4, Opus 4, Haiku 4.
@@ -85,7 +85,7 @@
 # Override with env var: AI_SHELL_OPENCODE_PROVIDER
 #
 # [opencode]
-# provider = "aws"
+# provider = "local"
 
 # =============================================================================
 # [container] - Docker container settings
@@ -113,8 +113,8 @@
 # webui_port: Host port for Open WebUI (default: 3000)
 #
 # [llm]
-# primary_model = "qwen3.5:27b"
-# fallback_model = "qwen3-coder-next"
+# primary_model = "qwen3-coder-next"
+# fallback_model = "qwen3.5:27b"
 # context_size = 32768
 # ollama_port = 11434
 # webui_port = 3000
@@ -125,4 +125,4 @@
 # model: LLM model string (default: ollama_chat/<primary_model>)
 #
 # [aider]
-# model = "ollama_chat/qwen3.5:27b"
+# model = "ollama_chat/qwen3-coder-next"

--- a/src/ai_shell/templates/aider/aider.conf.yml
+++ b/src/ai_shell/templates/aider/aider.conf.yml
@@ -3,8 +3,8 @@
 # Every CLI flag maps to a YAML key (use dashes, not underscores).
 
 # Model selection
-model: ollama_chat/qwen3.5:27b
-# weak-model: ollama_chat/qwen3.5:27b
+model: ollama_chat/qwen3-coder-next
+# weak-model: ollama_chat/qwen3-coder-next
 
 # Auto-accept changes (disable for interactive approval)
 yes-always: true

--- a/src/ai_shell/templates/opencode/opencode.json
+++ b/src/ai_shell/templates/opencode/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "ollama/qwen3.5:27b",
+  "model": "ollama/qwen3-coder-next",
   "provider": {
     "ollama": {
       "npm": "@ai-sdk/openai-compatible",

--- a/tests/unit/test_cli_llm.py
+++ b/tests/unit/test_cli_llm.py
@@ -110,8 +110,8 @@ class TestLlmCommands:
 
     def test_llm_pull(self, mock_config, mock_manager_cls):
         config = MagicMock()
-        config.primary_model = "qwen3.5:27b"
-        config.fallback_model = "qwen3-coder-next"
+        config.primary_model = "qwen3-coder-next"
+        config.fallback_model = "qwen3.5:27b"
         mock_config.return_value = config
 
         mock_manager = MagicMock()

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -156,12 +156,13 @@ class TestToolCommands:
         assert cmd == ["/bin/bash"]
         assert mock_manager.exec_interactive.call_args[1]["extra_env"] == TEST_EXEC_ENV
 
+    @patch("ai_shell.scaffold.scaffold_aider")
     def test_aider_passes_model_and_env(
-        self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+        self, mock_scaffold_aider, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
     ):
         mock_build_env.return_value = dict(TEST_EXEC_ENV)
         config = MagicMock()
-        config.aider_model = "ollama_chat/qwen3.5:27b"
+        config.aider_model = "ollama_chat/qwen3-coder-next"
         config.ollama_port = 11434
         mock_config.return_value = config
 
@@ -178,17 +179,18 @@ class TestToolCommands:
         extra_env = call_args[1].get("extra_env", {})
 
         assert "--model" in cmd
-        assert "ollama_chat/qwen3.5:27b" in cmd
+        assert "ollama_chat/qwen3-coder-next" in cmd
         assert "--yes-always" in cmd
         assert extra_env["OLLAMA_API_BASE"] == "http://host.docker.internal:11434"
         assert extra_env["GH_TOKEN"] == "test-token"
 
+    @patch("ai_shell.scaffold.scaffold_aider")
     def test_aider_safe_mode(
-        self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+        self, mock_scaffold_aider, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
     ):
         mock_build_env.return_value = dict(TEST_EXEC_ENV)
         config = MagicMock()
-        config.aider_model = "ollama_chat/qwen3.5:27b"
+        config.aider_model = "ollama_chat/qwen3-coder-next"
         mock_config.return_value = config
 
         mock_manager = MagicMock()
@@ -710,3 +712,97 @@ class TestCheckBedrockAccess:
         args = mock_run.call_args[0][0]
         shell_cmd = args[-1]
         assert "--profile" not in shell_cmd
+
+
+class TestAutoInit:
+    """Auto-init triggers scaffold on first run when config files are missing."""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    @patch("ai_shell.scaffold.scaffold_opencode")
+    def test_opencode_auto_inits_when_config_missing(
+        self, mock_scaffold, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        mock_build_env.return_value = {}
+        config = MagicMock()
+        config.opencode_provider = ""
+        mock_config.return_value = config
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["opencode"])
+
+        mock_scaffold.assert_called_once()
+
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    @patch("ai_shell.scaffold.scaffold_claude")
+    def test_claude_auto_inits_when_config_missing(
+        self, mock_scaffold, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        mock_build_env.return_value = {}
+        config = MagicMock()
+        config.claude_provider = ""
+        mock_config.return_value = config
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.run_interactive.return_value = (0, 30.0)
+        mock_manager_cls.return_value = mock_manager
+
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["claude"])
+
+        mock_scaffold.assert_called_once()
+
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    @patch("ai_shell.scaffold.scaffold_codex")
+    def test_codex_auto_inits_when_config_missing(
+        self, mock_scaffold, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        mock_build_env.return_value = {}
+        mock_config.return_value = MagicMock()
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["codex"])
+
+        mock_scaffold.assert_called_once()
+
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    @patch("ai_shell.scaffold.scaffold_aider")
+    def test_aider_auto_inits_when_config_missing(
+        self, mock_scaffold, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        mock_build_env.return_value = {}
+        config = MagicMock()
+        config.aider_model = "ollama_chat/qwen3-coder-next"
+        config.ollama_port = 11434
+        mock_config.return_value = config
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["aider"])
+
+        mock_scaffold.assert_called_once()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,7 @@ class TestAiShellConfig:
     def test_defaults(self):
         config = AiShellConfig()
         assert config.image == "svange/augint-shell"
-        assert config.primary_model == "qwen3.5:27b"
+        assert config.primary_model == "qwen3-coder-next"
         assert config.ollama_port == 11434
         assert config.webui_port == 3000
 

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -332,7 +332,7 @@ class TestScaffoldOpencode:
         scaffold_opencode(tmp_path)
         data = json.loads((tmp_path / "opencode.json").read_text())
         assert data["$schema"] == "https://opencode.ai/config.json"
-        assert data["model"] == "ollama/qwen3.5:27b"
+        assert data["model"] == "ollama/qwen3-coder-next"
         assert "host.docker.internal:11434" in data["provider"]["ollama"]["options"]["baseURL"]
 
     def test_opencode_json_has_permissions(self, tmp_path):
@@ -508,7 +508,7 @@ class TestScaffoldAider:
         scaffold_aider(tmp_path)
         content = (tmp_path / ".aider.conf.yml").read_text()
         data = yaml.safe_load(content)
-        assert data["model"] == "ollama_chat/qwen3.5:27b"
+        assert data["model"] == "ollama_chat/qwen3-coder-next"
 
     def test_aider_conf_has_notes_read(self, tmp_path):
         scaffold_aider(tmp_path)


### PR DESCRIPTION
## Summary

- Auto-scaffold missing config files on normal agent launch — running `ai-shell opencode` (or `claude`, `codex`, `aider`) in a fresh project now initializes the config automatically instead of requiring `--init` first
- Rename opencode provider keyword from `"ollama"` to `"local"` in docs/templates (both values still work in config files — no breaking change)
- Swap `DEFAULT_PRIMARY_MODEL` to `qwen3-coder-next`; `qwen3.5:27b` becomes the fallback
- Update all templates (`opencode.json`, `aider.conf.yml`, `ai-shell.toml`) to reflect new model defaults

## Checks run locally
- [x] Pre-commit hooks
- [x] Security scan (pip-audit — no vulnerabilities)
- [x] License compliance (no GPL/AGPL)
- [x] Unit tests with coverage (288 passed, 95.56% coverage)