### PR TITLE
feat(cli): add URLs and config to llm status output

### DIFF
--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -182,21 +182,42 @@ def llm_setup(ctx):
 @llm_group.command("status")
 @click.pass_context
 def llm_status(ctx):
-    """Show status of LLM stack and loaded models."""
+    """Show status of LLM stack, URLs, and loaded models."""
     manager = _get_manager(ctx)
+    config = manager.config
+    ollama_running = manager.container_status(OLLAMA_CONTAINER) == "running"
+    webui_running = manager.container_status(WEBUI_CONTAINER) == "running"
 
     console.print("[bold]Container status:[/bold]")
-    for name in [OLLAMA_CONTAINER, WEBUI_CONTAINER]:
+    for name, running in [(OLLAMA_CONTAINER, ollama_running), (WEBUI_CONTAINER, webui_running)]:
         status = manager.container_status(name)
-        if status == "running":
+        if running:
             console.print(f"  {name}: [green]{status}[/green]")
         elif status is not None:
             console.print(f"  {name}: [yellow]{status}[/yellow]")
         else:
             console.print(f"  {name}: [red]not found[/red]")
 
-    # Show models if ollama is running
-    if manager.container_status(OLLAMA_CONTAINER) == "running":
+    console.print("\n[bold]Access URLs:[/bold]")
+    ollama_url = f"http://localhost:{config.ollama_port}"
+    webui_url = f"http://localhost:{config.webui_port}"
+    if ollama_running:
+        console.print(f"  Ollama API:         [cyan]{ollama_url}[/cyan]")
+        console.print(f"  OpenAI-compatible:  [cyan]{ollama_url}/v1[/cyan]")
+    else:
+        console.print(f"  Ollama API:         [dim]{ollama_url}[/dim] (not running)")
+        console.print(f"  OpenAI-compatible:  [dim]{ollama_url}/v1[/dim] (not running)")
+    if webui_running:
+        console.print(f"  Open WebUI:         [cyan]{webui_url}[/cyan]")
+    else:
+        console.print(f"  Open WebUI:         [dim]{webui_url}[/dim] (not running)")
+
+    console.print("\n[bold]Configuration:[/bold]")
+    console.print(f"  Primary model:   {config.primary_model}")
+    console.print(f"  Fallback model:  {config.fallback_model}")
+    console.print(f"  Context window:  {config.context_size} tokens")
+
+    if ollama_running:
         console.print("\n[bold]Available models:[/bold]")
         output = manager.exec_in_ollama(["ollama", "list"])
         console.print(output)

--- a/tests/unit/test_cli_llm.py
+++ b/tests/unit/test_cli_llm.py
@@ -88,7 +88,16 @@ class TestLlmCommands:
         assert mock_manager.stop_container.call_count == 2
 
     def test_llm_status_running(self, mock_config, mock_manager_cls):
+        config = MagicMock()
+        config.ollama_port = 11434
+        config.webui_port = 3000
+        config.primary_model = "qwen3-coder-next"
+        config.fallback_model = "qwen3.5:27b"
+        config.context_size = 32768
+        mock_config.return_value = config
+
         mock_manager = MagicMock()
+        mock_manager.config = config
         mock_manager.container_status.return_value = "running"
         mock_manager.exec_in_ollama.return_value = "NAME\tSIZE\nqwen3.5:27b\t16GB"
         mock_manager_cls.return_value = mock_manager
@@ -97,9 +106,23 @@ class TestLlmCommands:
 
         assert result.exit_code == 0
         assert "running" in result.output
+        assert "http://localhost:11434" in result.output
+        assert "http://localhost:11434/v1" in result.output
+        assert "http://localhost:3000" in result.output
+        assert "qwen3-coder-next" in result.output
+        assert "32768" in result.output
 
     def test_llm_status_not_found(self, mock_config, mock_manager_cls):
+        config = MagicMock()
+        config.ollama_port = 11434
+        config.webui_port = 3000
+        config.primary_model = "qwen3-coder-next"
+        config.fallback_model = "qwen3.5:27b"
+        config.context_size = 32768
+        mock_config.return_value = config
+
         mock_manager = MagicMock()
+        mock_manager.config = config
         mock_manager.container_status.return_value = None
         mock_manager_cls.return_value = mock_manager
 
@@ -107,6 +130,8 @@ class TestLlmCommands:
 
         assert result.exit_code == 0
         assert "not found" in result.output
+        assert "http://localhost:11434" in result.output
+        assert "not running" in result.output
 
     def test_llm_pull(self, mock_config, mock_manager_cls):
         config = MagicMock()


### PR DESCRIPTION
## Summary
- `ai-shell llm status` now shows Ollama API URL, OpenAI-compatible endpoint (`/v1`), and Open WebUI URL
- Shows active model configuration (primary, fallback, context window)
- URLs are dimmed with `(not running)` when containers are offline so the address is still visible

## Checks run locally
- [x] Pre-commit hooks
- [x] Security scan (pip-audit)
- [x] License compliance
- [x] Unit tests with coverage (96%)