### PR TITLE
feat(gpu): intelligent VRAM management and CPU priority for Ollama

### DIFF
--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from ai_shell.config import load_config
 from ai_shell.container import ContainerManager
 from ai_shell.defaults import OLLAMA_CONTAINER, WEBUI_CONTAINER
+from ai_shell.gpu import get_vram_info, get_vram_processes
 
 console = Console(stderr=True)
 
@@ -216,6 +217,22 @@ def llm_status(ctx):
     console.print(f"  Primary model:   {config.primary_model}")
     console.print(f"  Fallback model:  {config.fallback_model}")
     console.print(f"  Context window:  {config.context_size} tokens")
+
+    vram = get_vram_info()
+    if vram is not None:
+        console.print("\n[bold]GPU VRAM:[/bold]")
+        console.print(
+            f"  Total: {vram['total'] / 1024**3:.1f} GiB  "
+            f"Used: {vram['used'] / 1024**3:.1f} GiB  "
+            f"Free: {vram['free'] / 1024**3:.1f} GiB"
+        )
+        processes = get_vram_processes()
+        console.print("\n  [bold]VRAM consumers:[/bold]")
+        if processes:
+            for pid, vram_mb, name in sorted(processes, key=lambda x: x[1], reverse=True):
+                console.print(f"    PID {pid:<8} {name:<20} {vram_mb / 1024:.1f} GiB")
+        else:
+            console.print("  (none)")
 
     if ollama_running:
         console.print("\n[bold]Available models:[/bold]")

--- a/src/ai_shell/container.py
+++ b/src/ai_shell/container.py
@@ -19,8 +19,10 @@ import docker
 from ai_shell.defaults import (
     LLM_NETWORK,
     OLLAMA_CONTAINER,
+    OLLAMA_CPU_SHARES,
     OLLAMA_DATA_VOLUME,
     OLLAMA_IMAGE,
+    OLLAMA_VRAM_BUFFER_BYTES,
     SHM_SIZE,
     WEBUI_CONTAINER,
     WEBUI_DATA_VOLUME,
@@ -34,7 +36,7 @@ from ai_shell.exceptions import (
     DockerNotAvailableError,
     ImagePullError,
 )
-from ai_shell.gpu import detect_gpu
+from ai_shell.gpu import detect_gpu, get_vram_info
 
 if TYPE_CHECKING:
     from docker.models.containers import Container
@@ -239,9 +241,21 @@ class ContainerManager:
         # GPU auto-detection
         gpu_available = detect_gpu()
         device_requests = None
+        env: dict[str, str] = {}
         if gpu_available:
             device_requests = [DeviceRequest(count=1, capabilities=[["gpu"]])]
-            logger.info("GPU detected - Ollama will use NVIDIA GPU")
+            vram = get_vram_info()
+            if vram:
+                overhead = vram["used"] + OLLAMA_VRAM_BUFFER_BYTES
+                env["OLLAMA_GPU_OVERHEAD"] = str(overhead)
+                logger.info(
+                    "VRAM: %.1f GiB total, %.1f GiB free. Reserving %.1f GiB overhead for Ollama.",
+                    vram["total"] / 1024**3,
+                    vram["free"] / 1024**3,
+                    overhead / 1024**3,
+                )
+            else:
+                logger.info("GPU detected - Ollama will use NVIDIA GPU")
         else:
             logger.warning("No GPU detected - Ollama will run on CPU (slower inference)")
 
@@ -259,10 +273,13 @@ class ContainerManager:
             "restart_policy": {"Name": "unless-stopped"},
             "detach": True,
             "network": network_name,
+            "cpu_shares": OLLAMA_CPU_SHARES,
         }
 
         if device_requests:
             kwargs["device_requests"] = device_requests
+        if env:
+            kwargs["environment"] = env
 
         self.client.containers.run(**kwargs)
         logger.info("Ollama container created on port %d", self.config.ollama_port)

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -48,6 +48,12 @@ DEFAULT_DEV_PORTS = [3000, 4200, 5000, 5173, 5678, 8000, 8080, 8888]
 DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
 # =============================================================================
+# Ollama GPU defaults
+# =============================================================================
+OLLAMA_VRAM_BUFFER_BYTES = 1 * 1024**3  # 1 GiB safety buffer reserved as overhead
+OLLAMA_CPU_SHARES = 1024  # Docker CPU scheduling priority (default 0 = fair-share)
+
+# =============================================================================
 # Container names
 # =============================================================================
 OLLAMA_CONTAINER = "augint-shell-ollama"

--- a/src/ai_shell/gpu.py
+++ b/src/ai_shell/gpu.py
@@ -6,6 +6,8 @@ import subprocess
 
 logger = logging.getLogger(__name__)
 
+_MIB = 1024 * 1024
+
 
 def detect_gpu() -> bool:
     """Check if NVIDIA GPU and Docker GPU runtime are available.
@@ -40,6 +42,77 @@ def _check_nvidia_smi() -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         logger.debug("nvidia-smi check failed: %s", e)
         return False
+
+
+def get_vram_info() -> dict[str, int] | None:
+    """Query current GPU VRAM usage.
+
+    Returns dict with keys total/free/used in bytes, or None if unavailable.
+    Uses the first GPU reported by nvidia-smi.
+    """
+    if not shutil.which("nvidia-smi"):
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.total,memory.free,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        line = result.stdout.strip().split("\n")[0]
+        parts = line.split(",")
+        if len(parts) != 3:
+            return None
+        total_mb, free_mb, used_mb = [int(p.strip()) for p in parts]
+        return {
+            "total": total_mb * _MIB,
+            "free": free_mb * _MIB,
+            "used": used_mb * _MIB,
+        }
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, ValueError) as e:
+        logger.debug("VRAM info query failed: %s", e)
+        return None
+
+
+def get_vram_processes() -> list[tuple[int, int, str]]:
+    """Query processes currently using GPU VRAM.
+
+    Returns list of (pid, vram_mb, name) tuples, empty list if unavailable.
+    """
+    if not shutil.which("nvidia-smi"):
+        return []
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,used_gpu_memory,name",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+        processes = []
+        for line in result.stdout.strip().split("\n"):
+            parts = line.split(",")
+            if len(parts) != 3:
+                continue
+            try:
+                processes.append((int(parts[0].strip()), int(parts[1].strip()), parts[2].strip()))
+            except ValueError:
+                continue
+        return processes
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.debug("VRAM process query failed: %s", e)
+        return []
 
 
 def _check_docker_gpu_runtime() -> bool:

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -237,7 +237,10 @@ class TestEnsureOllama:
         mock_container_manager._get_container = MagicMock(return_value=None)
         mock_container_manager._pull_image_if_needed = MagicMock()
 
-        with patch("ai_shell.container.detect_gpu", return_value=True):
+        with (
+            patch("ai_shell.container.detect_gpu", return_value=True),
+            patch("ai_shell.container.get_vram_info", return_value=None),
+        ):
             mock_container_manager.ensure_ollama()
 
         call_kwargs = mock_docker_client.containers.run.call_args[1]
@@ -249,12 +252,78 @@ class TestEnsureOllama:
         mock_container_manager._get_container = MagicMock(return_value=None)
         mock_container_manager._pull_image_if_needed = MagicMock()
 
-        with patch("ai_shell.container.detect_gpu", return_value=False):
+        with (
+            patch("ai_shell.container.detect_gpu", return_value=False),
+            patch("ai_shell.container.get_vram_info", return_value=None),
+        ):
             mock_container_manager.ensure_ollama()
 
         call_kwargs = mock_docker_client.containers.run.call_args[1]
         assert "device_requests" not in call_kwargs
         assert call_kwargs["network"] == LLM_NETWORK
+
+    def test_sets_gpu_overhead_when_vram_info_available(
+        self, mock_container_manager, mock_docker_client
+    ):
+        mock_container_manager._get_container = MagicMock(return_value=None)
+        mock_container_manager._pull_image_if_needed = MagicMock()
+        vram_info = {
+            "total": 24 * 1024**3,
+            "free": 20 * 1024**3,
+            "used": 4 * 1024**3,
+        }
+
+        with (
+            patch("ai_shell.container.detect_gpu", return_value=True),
+            patch("ai_shell.container.get_vram_info", return_value=vram_info),
+        ):
+            mock_container_manager.ensure_ollama()
+
+        call_kwargs = mock_docker_client.containers.run.call_args[1]
+        assert "environment" in call_kwargs
+        overhead = int(call_kwargs["environment"]["OLLAMA_GPU_OVERHEAD"])
+        assert overhead == 4 * 1024**3 + 1 * 1024**3  # used + 1 GiB buffer
+
+    def test_no_environment_when_vram_info_unavailable(
+        self, mock_container_manager, mock_docker_client
+    ):
+        mock_container_manager._get_container = MagicMock(return_value=None)
+        mock_container_manager._pull_image_if_needed = MagicMock()
+
+        with (
+            patch("ai_shell.container.detect_gpu", return_value=True),
+            patch("ai_shell.container.get_vram_info", return_value=None),
+        ):
+            mock_container_manager.ensure_ollama()
+
+        call_kwargs = mock_docker_client.containers.run.call_args[1]
+        assert "environment" not in call_kwargs
+
+    def test_no_environment_when_no_gpu(self, mock_container_manager, mock_docker_client):
+        mock_container_manager._get_container = MagicMock(return_value=None)
+        mock_container_manager._pull_image_if_needed = MagicMock()
+
+        with (
+            patch("ai_shell.container.detect_gpu", return_value=False),
+            patch("ai_shell.container.get_vram_info", return_value=None),
+        ):
+            mock_container_manager.ensure_ollama()
+
+        call_kwargs = mock_docker_client.containers.run.call_args[1]
+        assert "environment" not in call_kwargs
+
+    def test_always_sets_cpu_shares(self, mock_container_manager, mock_docker_client):
+        mock_container_manager._get_container = MagicMock(return_value=None)
+        mock_container_manager._pull_image_if_needed = MagicMock()
+
+        with (
+            patch("ai_shell.container.detect_gpu", return_value=False),
+            patch("ai_shell.container.get_vram_info", return_value=None),
+        ):
+            mock_container_manager.ensure_ollama()
+
+        call_kwargs = mock_docker_client.containers.run.call_args[1]
+        assert call_kwargs["cpu_shares"] == 1024
 
 
 class TestContainerLifecycle:

--- a/tests/unit/test_gpu.py
+++ b/tests/unit/test_gpu.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import MagicMock, patch
 
-from ai_shell.gpu import _check_docker_gpu_runtime, _check_nvidia_smi, detect_gpu
+from ai_shell.gpu import (
+    _check_docker_gpu_runtime,
+    _check_nvidia_smi,
+    detect_gpu,
+    get_vram_info,
+    get_vram_processes,
+)
 
 
 class TestDetectGpu:
@@ -65,6 +71,109 @@ class TestCheckNvidiaSmi:
             patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
         ):
             assert _check_nvidia_smi() is False
+
+
+class TestGetVramInfo:
+    def test_returns_none_when_nvidia_smi_not_found(self):
+        with patch("ai_shell.gpu.shutil.which", return_value=None):
+            assert get_vram_info() is None
+
+    def test_returns_bytes_on_success(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "24564, 20000, 4564\n"
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            info = get_vram_info()
+
+        assert info is not None
+        assert info["total"] == 24564 * 1024 * 1024
+        assert info["free"] == 20000 * 1024 * 1024
+        assert info["used"] == 4564 * 1024 * 1024
+
+    def test_uses_first_gpu_when_multiple(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "24564, 20000, 4564\n8192, 6000, 2192\n"
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            info = get_vram_info()
+
+        assert info is not None
+        assert info["total"] == 24564 * 1024 * 1024
+
+    def test_returns_none_on_subprocess_failure(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            assert get_vram_info() is None
+
+    def test_returns_none_on_unexpected_format(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "not, valid\n"
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            assert get_vram_info() is None
+
+
+class TestGetVramProcesses:
+    def test_returns_empty_when_nvidia_smi_not_found(self):
+        with patch("ai_shell.gpu.shutil.which", return_value=None):
+            assert get_vram_processes() == []
+
+    def test_returns_empty_on_no_output(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            assert get_vram_processes() == []
+
+    def test_parses_process_list(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "12345, 2100, chrome\n67890, 4500, ollama\n"
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            procs = get_vram_processes()
+
+        assert len(procs) == 2
+        assert procs[0] == (12345, 2100, "chrome")
+        assert procs[1] == (67890, 4500, "ollama")
+
+    def test_skips_malformed_lines(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "12345, 2100, chrome\nbad line\n67890, 4500, ollama\n"
+
+        with (
+            patch("ai_shell.gpu.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("ai_shell.gpu.subprocess.run", return_value=mock_result),
+        ):
+            procs = get_vram_processes()
+
+        assert len(procs) == 2
 
 
 class TestCheckDockerGpuRuntime:


### PR DESCRIPTION
## Summary
- Detects current GPU VRAM usage via `nvidia-smi` at `llm up` time and sets `OLLAMA_GPU_OVERHEAD` so Ollama only claims what is actually free — enables partial GPU offload for large models instead of hard OOM failure when the system is under load
- Raises Ollama's Docker CPU shares to 1024 for higher scheduling priority during CPU-offloaded inference layers
- Adds a GPU VRAM section to `llm status` showing total/free/used and a sorted table of processes currently consuming VRAM

## Checks run locally
- [x] Pre-commit hooks (ruff, mypy, uv.lock)
- [x] Security scan (pip-audit — no vulnerabilities)
- [x] Unit tests — 301 passed, 95% coverage