### PR TITLE
feat(cli): add -h as alias for --help

### DIFF
--- a/src/ai_shell/cli/__init__.py
+++ b/src/ai_shell/cli/__init__.py
@@ -1,0 +1,3 @@
+"""CLI package for ai-shell."""
+
+CONTEXT_SETTINGS: dict = {"help_option_names": ["-h", "--help"]}

--- a/src/ai_shell/cli/__main__.py
+++ b/src/ai_shell/cli/__main__.py
@@ -6,12 +6,13 @@ import sys
 import click
 
 from ai_shell import __version__
+from ai_shell.cli import CONTEXT_SETTINGS
 from ai_shell.cli.commands.llm import llm_group
 from ai_shell.cli.commands.manage import manage_group
 from ai_shell.cli.commands.tools import aider, claude, codex, init, opencode, shell
 
 
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option(version=__version__, prog_name="ai-shell")
 @click.option("--project", default=None, help="Override project name for container naming.")
 @click.option("--verbose", "-v", is_flag=True, default=False, help="Enable debug logging.")

--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from ai_shell.cli import CONTEXT_SETTINGS
 from ai_shell.config import load_config
 from ai_shell.container import ContainerManager
 from ai_shell.defaults import OLLAMA_CONTAINER, WEBUI_CONTAINER
@@ -55,7 +56,7 @@ def _get_manager(ctx) -> ContainerManager:
     return ContainerManager(config)
 
 
-@click.group("llm")
+@click.group("llm", context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 def llm_group(ctx):
     """Manage the local LLM stack (Ollama + Open WebUI)."""

--- a/src/ai_shell/cli/commands/manage.py
+++ b/src/ai_shell/cli/commands/manage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from ai_shell.cli import CONTEXT_SETTINGS
 from ai_shell.config import load_config
 from ai_shell.container import ContainerManager
 from ai_shell.defaults import build_dev_environment, dev_container_name
@@ -20,7 +21,7 @@ def _get_manager(ctx) -> ContainerManager:
     return ContainerManager(config)
 
 
-@click.group("manage")
+@click.group("manage", context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 def manage_group(ctx):
     """Manage dev containers."""

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from ai_shell.cli import CONTEXT_SETTINGS
 from ai_shell.config import AiShellConfig, load_config
 from ai_shell.container import ContainerManager
 from ai_shell.defaults import build_dev_environment
@@ -245,7 +246,7 @@ def _get_manager(
     return manager, container_name, exec_env, config
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--init",
     "do_init",
@@ -392,7 +393,7 @@ def claude(
             sys.exit(exit_code)
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--init",
     "do_init",
@@ -536,7 +537,7 @@ def codex(
     manager.exec_interactive(name, cmd, extra_env=exec_env)
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--init",
     "do_init",
@@ -667,7 +668,7 @@ def opencode(
     manager.exec_interactive(name, cmd, extra_env=exec_env)
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--init",
     "do_init",
@@ -744,7 +745,7 @@ def aider(ctx, do_init, do_update, do_reset, do_clean, safe, repo_type_flag, ext
     manager.exec_interactive(name, cmd, extra_env=exec_env)
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 def shell(ctx):
     """Open a bash shell in the dev container."""
@@ -753,7 +754,7 @@ def shell(ctx):
     manager.exec_interactive(name, ["/bin/bash"], extra_env=exec_env)
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--update",
     is_flag=True,

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -978,3 +978,30 @@ class TestAutoInit:
             self.runner.invoke(cli, ["aider"])
 
         mock_scaffold.assert_called_once()
+
+
+class TestHelpShortFlag:
+    """Verify -h works as alias for --help across all groups and commands."""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_main_group_h_flag(self):
+        result = self.runner.invoke(cli, ["-h"])
+        assert result.exit_code == 0
+        assert "Usage" in result.output
+
+    def test_claude_h_flag(self):
+        result = self.runner.invoke(cli, ["claude", "-h"])
+        assert result.exit_code == 0
+        assert "Usage" in result.output
+
+    def test_llm_h_flag(self):
+        result = self.runner.invoke(cli, ["llm", "-h"])
+        assert result.exit_code == 0
+        assert "Usage" in result.output
+
+    def test_manage_h_flag(self):
+        result = self.runner.invoke(cli, ["manage", "-h"])
+        assert result.exit_code == 0
+        assert "Usage" in result.output


### PR DESCRIPTION
## Summary
- Adds `-h` as a short alias for `--help` across all CLI groups and commands (standard Unix convention)
- Defines shared `CONTEXT_SETTINGS` in `ai_shell.cli` package, applied to 3 groups + 6 commands
- Adds 4 tests verifying `-h` works on main group, claude command, llm group, and manage group

Closes #45

## Test plan
- [x] `ai-shell -h` shows help
- [x] `ai-shell claude -h` shows help
- [x] `ai-shell llm -h` shows help
- [x] `ai-shell manage -h` shows help
- [x] 328 tests pass, 95% coverage
- [x] Pre-commit clean (ruff, mypy, formatting)