### PR TITLE
feat: mount ~/.config/gh and fall back to hosts.yml for GH_TOKEN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ CLI commands (cli/commands/)
 
 ### Mount Assembly
 
-Dev containers mount: project dir, UV cache volume (shared), and conditionally: `~/.claude`, `~/.codex`, `~/.ssh` (ro), `~/.aws`, `~/.gitconfig` (ro), `~/projects/CLAUDE.md` (ro), Docker socket (ro), plus `extra_volumes` from config.
+Dev containers mount: project dir, UV cache volume (shared), and conditionally: `~/.claude`, `~/.codex`, `~/.ssh` (ro), `~/.aws`, `~/.config/gh`, `~/.gitconfig` (ro), `~/projects/CLAUDE.md` (ro), Docker socket (ro), plus `extra_volumes` from config.
 
 ### Environment Assembly
 

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -148,6 +148,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
         (home / ".ssh", "/root/.ssh", True),
         (home / ".gitconfig", "/root/.gitconfig.windows", True),
         (home / ".aws", "/root/.aws", False),
+        (home / ".config" / "gh", "/root/.config/gh", False),
     ]
 
     for source, target, read_only in optional_binds:
@@ -196,6 +197,25 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
     return mounts
 
 
+def _read_gh_hosts_token(gh_config_dir: Path) -> str:
+    """Read oauth_token for github.com from ~/.config/gh/hosts.yml.
+
+    Returns empty string if the file is missing, unreadable, or malformed.
+    """
+    import yaml
+
+    hosts_file = gh_config_dir / "hosts.yml"
+    if not hosts_file.exists():
+        return ""
+    try:
+        with hosts_file.open() as f:
+            data = yaml.safe_load(f)
+        return str(data.get("github.com", {}).get("oauth_token", "")) or ""
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not read GH token from %s", hosts_file)
+        return ""
+
+
 def build_dev_environment(
     extra_env: dict[str, str] | None = None,
     project_dir: Path | None = None,
@@ -235,12 +255,13 @@ def build_dev_environment(
             return dotenv_val
         return os.environ.get(key, default)
 
+    gh_token = _resolve("GH_TOKEN") or _read_gh_hosts_token(Path.home() / ".config" / "gh")
     env: dict[str, str] = {
         "AWS_PROFILE": aws_profile or _resolve("AWS_PROFILE"),
         "AWS_REGION": aws_region or _resolve("AWS_REGION", "us-east-1"),
         "AWS_PAGER": "",
-        "GH_TOKEN": _resolve("GH_TOKEN"),
-        "GITHUB_TOKEN": _resolve("GH_TOKEN"),
+        "GH_TOKEN": gh_token,
+        "GITHUB_TOKEN": gh_token,
         "HUSKY": "0",
         "IS_SANDBOX": "1",
     }

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -121,6 +121,7 @@ class TestBuildDevMounts:
         # Optional mounts should NOT be present since paths don't exist
         assert "/root/.ssh" not in targets
         assert "/root/.claude" not in targets
+        assert "/root/.config/gh" not in targets
 
     def test_includes_existing_optional_paths(self, tmp_path):
         project_dir = tmp_path / "test-project"
@@ -131,6 +132,7 @@ class TestBuildDevMounts:
         (fake_home / ".ssh").mkdir()
         (fake_home / ".claude").mkdir()
         (fake_home / ".aws").mkdir()
+        (fake_home / ".config" / "gh").mkdir(parents=True)
 
         with patch("ai_shell.defaults.Path.home", return_value=fake_home):
             mounts = build_dev_mounts(project_dir, "test-project")
@@ -139,6 +141,7 @@ class TestBuildDevMounts:
         assert "/root/.ssh" in targets
         assert "/root/.claude" in targets
         assert "/root/.aws" in targets
+        assert "/root/.config/gh" in targets
 
 
 class TestBuildDevEnvironment:
@@ -312,3 +315,54 @@ class TestBuildDevEnvironmentTeamMode:
     def test_team_mode_false_no_agent_teams_env(self):
         env = build_dev_environment(team_mode=False)
         assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in env
+
+
+class TestBuildDevEnvironmentGhToken:
+    def test_falls_back_to_hosts_yml_when_no_token(self, tmp_path):
+        gh_dir = tmp_path / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        (gh_dir / "hosts.yml").write_text("github.com:\n  oauth_token: ghp_from_hosts\n")
+        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
+            "os.environ", {}, clear=True
+        ):
+            env = build_dev_environment()
+        assert env["GH_TOKEN"] == "ghp_from_hosts"
+        assert env["GITHUB_TOKEN"] == "ghp_from_hosts"
+
+    def test_dotenv_takes_precedence_over_hosts_yml(self, tmp_path):
+        gh_dir = tmp_path / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        (gh_dir / "hosts.yml").write_text("github.com:\n  oauth_token: ghp_from_hosts\n")
+        (tmp_path / ".env").write_text("GH_TOKEN=ghp_from_dotenv\n")
+        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
+            "os.environ", {}, clear=True
+        ):
+            env = build_dev_environment(project_dir=tmp_path)
+        assert env["GH_TOKEN"] == "ghp_from_dotenv"
+
+    def test_os_environ_takes_precedence_over_hosts_yml(self, tmp_path):
+        gh_dir = tmp_path / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        (gh_dir / "hosts.yml").write_text("github.com:\n  oauth_token: ghp_from_hosts\n")
+        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
+            "os.environ", {"GH_TOKEN": "ghp_from_env"}
+        ):
+            env = build_dev_environment()
+        assert env["GH_TOKEN"] == "ghp_from_env"
+
+    def test_missing_hosts_yml_returns_empty(self, tmp_path):
+        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
+            "os.environ", {}, clear=True
+        ):
+            env = build_dev_environment()
+        assert env["GH_TOKEN"] == ""
+
+    def test_malformed_hosts_yml_returns_empty(self, tmp_path):
+        gh_dir = tmp_path / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        (gh_dir / "hosts.yml").write_text("not: valid: yaml: [")
+        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
+            "os.environ", {}, clear=True
+        ):
+            env = build_dev_environment()
+        assert env["GH_TOKEN"] == ""

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -322,8 +322,9 @@ class TestBuildDevEnvironmentGhToken:
         gh_dir = tmp_path / ".config" / "gh"
         gh_dir.mkdir(parents=True)
         (gh_dir / "hosts.yml").write_text("github.com:\n  oauth_token: ghp_from_hosts\n")
-        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
-            "os.environ", {}, clear=True
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {}, clear=True),
         ):
             env = build_dev_environment()
         assert env["GH_TOKEN"] == "ghp_from_hosts"
@@ -334,8 +335,9 @@ class TestBuildDevEnvironmentGhToken:
         gh_dir.mkdir(parents=True)
         (gh_dir / "hosts.yml").write_text("github.com:\n  oauth_token: ghp_from_hosts\n")
         (tmp_path / ".env").write_text("GH_TOKEN=ghp_from_dotenv\n")
-        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
-            "os.environ", {}, clear=True
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {}, clear=True),
         ):
             env = build_dev_environment(project_dir=tmp_path)
         assert env["GH_TOKEN"] == "ghp_from_dotenv"
@@ -344,15 +346,17 @@ class TestBuildDevEnvironmentGhToken:
         gh_dir = tmp_path / ".config" / "gh"
         gh_dir.mkdir(parents=True)
         (gh_dir / "hosts.yml").write_text("github.com:\n  oauth_token: ghp_from_hosts\n")
-        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
-            "os.environ", {"GH_TOKEN": "ghp_from_env"}
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {"GH_TOKEN": "ghp_from_env"}),
         ):
             env = build_dev_environment()
         assert env["GH_TOKEN"] == "ghp_from_env"
 
     def test_missing_hosts_yml_returns_empty(self, tmp_path):
-        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
-            "os.environ", {}, clear=True
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {}, clear=True),
         ):
             env = build_dev_environment()
         assert env["GH_TOKEN"] == ""
@@ -361,8 +365,9 @@ class TestBuildDevEnvironmentGhToken:
         gh_dir = tmp_path / ".config" / "gh"
         gh_dir.mkdir(parents=True)
         (gh_dir / "hosts.yml").write_text("not: valid: yaml: [")
-        with patch("ai_shell.defaults.Path.home", return_value=tmp_path), patch.dict(
-            "os.environ", {}, clear=True
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {}, clear=True),
         ):
             env = build_dev_environment()
         assert env["GH_TOKEN"] == ""


### PR DESCRIPTION
## Summary

- Mounts `~/.config/gh` into dev containers (read-write, conditional on path existing) — gives `gh` CLI access to host SSO/OAuth credentials
- Adds `_read_gh_hosts_token()` helper to read `oauth_token` from `~/.config/gh/hosts.yml`
- `GH_TOKEN` / `GITHUB_TOKEN` now fall back to the hosts.yml token when not set via `extra_env`, `.env`, or `os.environ`

Priority chain: `extra_env` > `.env` > `os.environ` > `~/.config/gh/hosts.yml` > `""`

## Test plan

- [x] `uv run pytest tests/unit/test_defaults.py -v` — 52 tests pass (8 new)
- [x] Mount present when `~/.config/gh` exists, absent when it doesn't
- [x] `.env` / `os.environ` take precedence over `hosts.yml`
- [x] Malformed or missing `hosts.yml` returns empty string safely