### PR TITLE
feat: use named volume for gh config when no host path found

### DIFF
--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -28,6 +28,7 @@ SHM_SIZE = "2g"
 # Volume names (prefixed to avoid collisions)
 # =============================================================================
 UV_CACHE_VOLUME = "augint-shell-uv-cache"
+GH_CONFIG_VOLUME = "augint-shell-gh-config"
 
 
 def uv_venv_path(repo_name: str, worktree_name: str | None = None) -> str:
@@ -163,7 +164,9 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
         else:
             logger.debug("Skipping optional mount (not found): %s", source)
 
-    # Optional: gh CLI config (Linux/Mac path or WSL2 Windows APPDATA path)
+    # gh CLI config: bind-mount the host path when found (Linux/Mac/WSL2),
+    # otherwise use a named volume so auth persists across container recreations
+    # (needed on Windows where gh stores tokens in keyring, not a file).
     gh_config = _find_gh_config_dir()
     if gh_config is not None:
         mounts.append(
@@ -172,6 +175,14 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
                 source=str(gh_config),
                 type="bind",
                 read_only=False,
+            )
+        )
+    else:
+        mounts.append(
+            Mount(
+                target="/root/.config/gh",
+                source=GH_CONFIG_VOLUME,
+                type="volume",
             )
         )
 

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from ai_shell.defaults import (
     CONTAINER_PREFIX,
+    GH_CONFIG_VOLUME,
     NPM_CACHE_VOLUME,
     UV_CACHE_VOLUME,
     build_dev_environment,
@@ -109,19 +110,24 @@ class TestBuildDevMounts:
         project_dir.mkdir()
 
         # With a fake home that has nothing in it
-        with patch("ai_shell.defaults.Path.home", return_value=tmp_path / "fakehome"):
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path / "fakehome"),
+            patch.dict("os.environ", {}, clear=True),
+        ):
             (tmp_path / "fakehome").mkdir()
             mounts = build_dev_mounts(project_dir, "test-project")
 
-        # Should have project dir + cache volumes, but no optional mounts
         targets = [m.get("Target") for m in mounts]
         assert "/root/projects/test-project" in targets
         assert "/root/.cache/uv" in targets
         assert "/root/.npm" in targets
-        # Optional mounts should NOT be present since paths don't exist
         assert "/root/.ssh" not in targets
         assert "/root/.claude" not in targets
-        assert "/root/.config/gh" not in targets
+        # No host path found → falls back to named volume (not a bind mount)
+        gh_mount = next((m for m in mounts if m.get("Target") == "/root/.config/gh"), None)
+        assert gh_mount is not None
+        assert gh_mount.get("Type") == "volume"
+        assert gh_mount.get("Source") == GH_CONFIG_VOLUME
 
     def test_includes_existing_optional_paths(self, tmp_path):
         project_dir = tmp_path / "test-project"
@@ -134,14 +140,20 @@ class TestBuildDevMounts:
         (fake_home / ".aws").mkdir()
         (fake_home / ".config" / "gh").mkdir(parents=True)
 
-        with patch("ai_shell.defaults.Path.home", return_value=fake_home):
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=fake_home),
+            patch.dict("os.environ", {}, clear=True),
+        ):
             mounts = build_dev_mounts(project_dir, "test-project")
 
         targets = [m.get("Target") for m in mounts]
         assert "/root/.ssh" in targets
         assert "/root/.claude" in targets
         assert "/root/.aws" in targets
-        assert "/root/.config/gh" in targets
+        # Host path found → bind mount (not named volume)
+        gh_mount = next((m for m in mounts if m.get("Target") == "/root/.config/gh"), None)
+        assert gh_mount is not None
+        assert gh_mount.get("Type") == "bind"
 
 
 class TestBuildDevEnvironment:


### PR DESCRIPTION
## Summary

- Adds `GH_CONFIG_VOLUME = "augint-shell-gh-config"` named volume
- When `_find_gh_config_dir()` finds no host path (Windows with keyring, no WSL2 `~/.config/gh`), mounts the named volume at `/root/.config/gh` instead of nothing
- This means `gh auth login` inside a container persists across `manage clean` / container recreations on Windows
- Linux/Mac users with `~/.config/gh` still get a bind mount (unchanged behavior)

## How to use on Windows
1. `ai-shell manage clean` to get a fresh container on the new version
2. Inside the container: `gh auth login` (device code or browser)
3. Auth is now stored in the `augint-shell-gh-config` Docker volume — all future containers will be pre-authenticated

## Test plan

- [x] 54 tests pass
- [x] No host path → named volume mounted at `/root/.config/gh`
- [x] Host path found → bind mount (not volume)