### PR TITLE
feat: interactive multi-pane wizard and local Chrome bridge

### DIFF
--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -273,6 +273,141 @@ def _load_workspace_repos(workspace_yaml: Path) -> tuple[str, list[dict[str, Any
     return workspace_name, repos
 
 
+def _launch_interactive_multi(
+    ctx: click.Context,
+    *,
+    safe: bool,
+    use_aws: bool,
+    cli_profile: str | None,
+    skip_preflight: bool,
+    extra_args: tuple[str, ...],
+) -> None:
+    """Interactive multi-pane launcher.
+
+    Walks the user through a guided wizard to configure each tmux pane,
+    then builds and launches the customised tmux session.
+    """
+    from ai_shell.interactive import build_interactive_panes, run_interactive_wizard
+    from ai_shell.tmux import (
+        TMUX_SESSION_PREFIX,
+        build_attach_command,
+        build_check_session_command,
+        build_tmux_commands,
+    )
+
+    # Load config early -- needed for session check and container setup.
+    project = ctx.obj.get("project") if ctx.obj else None
+    config = load_config(project_override=project, project_dir=Path.cwd())
+    session_name = f"{TMUX_SESSION_PREFIX}-{config.project_name}"
+    container_name = dev_container_name(config.project_name, config.project_dir)
+
+    # Check for existing tmux session.
+    check_cmd = build_check_session_command(container_name, session_name)
+    has_session = subprocess.run(check_cmd, capture_output=True).returncode == 0
+
+    if has_session:
+        console.print(f"[bold]Found existing tmux session '[cyan]{session_name}[/cyan]'.[/bold]")
+        choice = click.prompt(
+            "  Reconnect, start fresh, or cancel?",
+            type=click.Choice(["reconnect", "fresh", "cancel"], case_sensitive=False),
+            default="reconnect",
+        )
+        if choice == "reconnect":
+            attach_cmd = build_attach_command(container_name, session_name)
+            logger.debug("tmux reattach: %s", " ".join(attach_cmd))
+            sys.stdout.flush()
+            sys.stderr.flush()
+            attach = subprocess.run(attach_cmd)
+            sys.exit(attach.returncode)
+        elif choice == "cancel":
+            return
+        # choice == "fresh": fall through to wizard
+
+    # Gather workspace repos if available.
+    workspace_yaml = Path.cwd() / "workspace.yaml"
+    workspace_repos = None
+    if workspace_yaml.exists():
+        _, workspace_repos = _load_workspace_repos(workspace_yaml)
+
+    # Run the wizard.
+    interactive_config = run_interactive_wizard(
+        project_name=config.project_name,
+        workspace_repos=workspace_repos,
+    )
+    if interactive_config is None:
+        console.print("[dim]Cancelled.[/dim]")
+        return
+
+    # Ensure container is running.
+    use_bedrock = use_aws or config.claude_provider == "aws"
+    manager = ContainerManager(config)
+    container_name = manager.ensure_dev_container()
+    exec_env = build_dev_environment(
+        config.extra_env,
+        config.project_dir,
+        project_name=config.project_name,
+        bedrock=use_bedrock,
+        aws_profile=config.ai_profile,
+        aws_region=config.aws_region,
+        bedrock_profile=cli_profile or config.bedrock_profile,
+    )
+
+    if use_bedrock and not skip_preflight:
+        _check_bedrock_access(container_name, exec_env)
+
+    # Handle shared Chrome if requested.
+    mcp_config_path: str | None = None
+    if interactive_config.shared_chrome:
+        from ai_shell.local_chrome import (
+            LocalChromeUnavailable,
+            ensure_host_chrome,
+            start_chrome_proxy,
+            write_mcp_config,
+        )
+
+        console.print("[dim]Connecting to host Chrome...[/dim]")
+        try:
+            chrome_port = ensure_host_chrome(container_name)
+        except LocalChromeUnavailable as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        start_chrome_proxy(container_name, chrome_port)
+        host_mcp_path = write_mcp_config(chrome_port)
+        mcp_config_path = "/etc/ai-shell/chrome-mcp.json"
+        _inject_mcp_config(container_name, str(host_mcp_path), mcp_config_path)
+        console.print("[dim]Chrome DevTools MCP attached.[/dim]")
+
+    # Build pane specs.
+    container_project_root = f"/root/projects/{config.project_name}"
+    panes = build_interactive_panes(
+        config=interactive_config,
+        project_name=config.project_name,
+        container_name=container_name,
+        container_project_root=container_project_root,
+        safe=safe,
+        extra_args=extra_args,
+        mcp_config_path=mcp_config_path,
+        setup_worktree_fn=_setup_worktree,
+    )
+
+    # Build and run tmux commands.
+    cmds = build_tmux_commands(container_name, session_name, panes)
+
+    console.print(f"[bold]Launching {len(panes)} panes in tmux session '{session_name}'...[/bold]")
+
+    for cmd_args in cmds[:-1]:
+        result = subprocess.run(cmd_args, capture_output=True, text=True)
+        if result.returncode != 0 and "kill-session" not in " ".join(cmd_args):
+            logger.debug("tmux setup command failed: %s\n%s", cmd_args, result.stderr)
+
+    final_cmd = cmds[-1]
+    logger.debug("tmux attach: %s", " ".join(final_cmd))
+    sys.stdout.flush()
+    sys.stderr.flush()
+    attach = subprocess.run(final_cmd)
+    sys.exit(attach.returncode)
+
+
 def _launch_team(
     ctx: click.Context,
     *,
@@ -762,6 +897,18 @@ def _launch_multi(
         "over your real Windows Chrome tabs."
     ),
 )
+@click.option(
+    "--interactive",
+    "-i",
+    "do_interactive",
+    is_flag=True,
+    default=False,
+    help=(
+        "Interactive multi-pane setup: walk through a guided menu to "
+        "configure window types, teams mode, and shared Chrome before "
+        "launching tmux.  Requires --multi."
+    ),
+)
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def claude(
@@ -778,6 +925,7 @@ def claude(
     do_multi,
     do_team,
     local_chrome,
+    do_interactive,
     extra_args,
 ):
     """Launch Claude Code in the dev container."""
@@ -788,6 +936,17 @@ def claude(
         raise click.ClickException("--team and --multi are incompatible (both manage tmux).")
     if do_team and any([do_init, do_update, do_reset, do_clean]):
         raise click.ClickException("--team is incompatible with --init/--update/--reset/--clean.")
+    if do_interactive and not do_multi:
+        raise click.ClickException("--interactive requires --multi.")
+    if do_interactive and do_team:
+        raise click.ClickException(
+            "--interactive and --team are incompatible (interactive handles teams mode itself)."
+        )
+    if do_interactive and local_chrome:
+        raise click.ClickException(
+            "--interactive and --local-chrome are incompatible "
+            "(interactive handles Chrome setup itself)."
+        )
 
     if do_init or do_update or do_reset or do_clean:
         from ai_shell.scaffold import scaffold_claude as _scaffold_claude
@@ -801,6 +960,16 @@ def claude(
         return
 
     if do_multi:
+        if do_interactive:
+            _launch_interactive_multi(
+                ctx,
+                safe=safe,
+                use_aws=use_aws,
+                cli_profile=cli_profile,
+                skip_preflight=skip_preflight,
+                extra_args=extra_args,
+            )
+            return
         _launch_multi(
             ctx,
             safe=safe,

--- a/src/ai_shell/interactive.py
+++ b/src/ai_shell/interactive.py
@@ -1,0 +1,249 @@
+"""Interactive multi-pane wizard for ``ai-shell claude --multi -i``.
+
+Walks the user through a guided menu to configure each tmux pane,
+then converts the collected choices into :class:`~ai_shell.tmux.PaneSpec`
+objects ready for :func:`~ai_shell.tmux.build_tmux_commands`.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import click
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from ai_shell.tmux import PaneSpec
+
+
+# ── Data model ───────────────────────────────────────────────────────
+
+
+class PaneType(enum.Enum):
+    """Types of panes available in interactive mode."""
+
+    THIS_PROJECT = "this_project"
+    BASH = "bash"
+    WORKSPACE_REPO = "workspace_repo"
+
+
+@dataclass
+class PaneChoice:
+    """A user's selection for a single window."""
+
+    pane_type: PaneType
+    repo_name: str = ""
+    repo_path: str = ""
+
+
+@dataclass
+class InteractiveConfig:
+    """Collected results from the interactive wizard."""
+
+    pane_choices: list[PaneChoice] = field(default_factory=list)
+    team_mode: bool = False
+    shared_chrome: bool = False
+
+
+# ── Option builder ───────────────────────────────────────────────────
+
+
+@dataclass
+class _PaneOption:
+    """A single numbered option in the per-window menu."""
+
+    label: str
+    pane_type: PaneType
+    repo_name: str = ""
+    repo_path: str = ""
+
+
+def _build_pane_options(
+    project_name: str,
+    workspace_repos: list[dict[str, Any]] | None,
+) -> list[_PaneOption]:
+    """Build the numbered option list for per-window type selection."""
+    options: list[_PaneOption] = [
+        _PaneOption(
+            label=f"This project ({project_name}) - Claude in worktree",
+            pane_type=PaneType.THIS_PROJECT,
+        ),
+        _PaneOption(
+            label="Bash shell",
+            pane_type=PaneType.BASH,
+        ),
+    ]
+    if workspace_repos:
+        for repo in workspace_repos:
+            name = repo["name"]
+            path = repo.get("path", f"./{name}")
+            repo_type = repo.get("repo_type", "")
+            label = f"{name} ({repo_type})" if repo_type else name
+            options.append(
+                _PaneOption(
+                    label=label,
+                    pane_type=PaneType.WORKSPACE_REPO,
+                    repo_name=name,
+                    repo_path=path,
+                )
+            )
+    return options
+
+
+# ── Wizard ───────────────────────────────────────────────────────────
+
+
+def run_interactive_wizard(
+    *,
+    project_name: str,
+    workspace_repos: list[dict[str, Any]] | None = None,
+    console: Console | None = None,
+) -> InteractiveConfig | None:
+    """Walk the user through the interactive multi-pane setup.
+
+    Returns :class:`InteractiveConfig` with all choices, or ``None`` if the
+    user cancels (Ctrl-C / EOFError).
+    """
+    if console is None:
+        console = Console(stderr=True)
+
+    options = _build_pane_options(project_name, workspace_repos)
+
+    try:
+        # Step 1: number of windows
+        num_windows: int = click.prompt(
+            "How many windows?",
+            type=click.IntRange(2, 4),
+            default=2,
+        )
+
+        # Step 2: per-window type
+        choices: list[PaneChoice] = []
+        for win_idx in range(1, num_windows + 1):
+            console.print()
+            console.print(f"  [bold]Window {win_idx}:[/bold]")
+            for i, opt in enumerate(options, 1):
+                console.print(f"    {i}. {opt.label}")
+
+            selection: int = click.prompt(
+                f"  Select type for window {win_idx}",
+                type=click.IntRange(1, len(options)),
+                default=1,
+            )
+            chosen = options[selection - 1]
+            choices.append(
+                PaneChoice(
+                    pane_type=chosen.pane_type,
+                    repo_name=chosen.repo_name,
+                    repo_path=chosen.repo_path,
+                )
+            )
+
+        # Step 3: pre-launch options
+        console.print()
+        team_mode = click.confirm(
+            "Enable teams mode on the primary Claude pane?",
+            default=False,
+        )
+        shared_chrome = click.confirm(
+            "Enable shared Chrome browser for all Claude panes?",
+            default=False,
+        )
+
+    except (EOFError, KeyboardInterrupt, click.Abort):
+        return None
+
+    return InteractiveConfig(
+        pane_choices=choices,
+        team_mode=team_mode,
+        shared_chrome=shared_chrome,
+    )
+
+
+# ── Pane builder ─────────────────────────────────────────────────────
+
+
+def build_interactive_panes(
+    *,
+    config: InteractiveConfig,
+    project_name: str,
+    container_name: str,
+    container_project_root: str,
+    safe: bool,
+    extra_args: tuple[str, ...],
+    mcp_config_path: str | None = None,
+    setup_worktree_fn: Callable[[str, str, str], str],
+) -> list[PaneSpec]:
+    """Convert :class:`InteractiveConfig` into pane specs for tmux.
+
+    Parameters
+    ----------
+    setup_worktree_fn
+        ``(container_name, project_dir, worktree_name) -> worktree_abs_path``.
+        In production this is ``tools._setup_worktree``; in tests, a mock.
+    """
+    from ai_shell.tmux import PaneSpec, build_claude_pane_command
+
+    panes: list[PaneSpec] = []
+    team_assigned = False
+    bash_counter = 0
+
+    for choice in config.pane_choices:
+        if choice.pane_type == PaneType.THIS_PROJECT:
+            wt_name = uuid.uuid4().hex[:8]
+            worktree_dir = setup_worktree_fn(container_name, container_project_root, wt_name)
+            use_team = config.team_mode and not team_assigned
+            pane_cmd = build_claude_pane_command(
+                repo_name=project_name,
+                safe=safe,
+                extra_args=extra_args,
+                worktree_name=wt_name,
+                mcp_config_path=mcp_config_path if config.shared_chrome else None,
+                team_env=use_team,
+            )
+            if use_team:
+                team_assigned = True
+            panes.append(
+                PaneSpec(
+                    name=f"{project_name}-wt-{wt_name}",
+                    command=pane_cmd,
+                    working_dir=worktree_dir,
+                )
+            )
+
+        elif choice.pane_type == PaneType.BASH:
+            bash_counter += 1
+            panes.append(
+                PaneSpec(
+                    name=f"bash-{bash_counter}",
+                    command="/bin/bash",
+                    working_dir=container_project_root,
+                )
+            )
+
+        elif choice.pane_type == PaneType.WORKSPACE_REPO:
+            rel = choice.repo_path.lstrip("./")
+            working_dir = f"{container_project_root}/{rel}"
+            use_team = config.team_mode and not team_assigned
+            pane_cmd = build_claude_pane_command(
+                repo_name=choice.repo_name,
+                safe=safe,
+                extra_args=extra_args,
+                mcp_config_path=mcp_config_path if config.shared_chrome else None,
+                team_env=use_team,
+            )
+            if use_team:
+                team_assigned = True
+            panes.append(
+                PaneSpec(
+                    name=choice.repo_name,
+                    command=pane_cmd,
+                    working_dir=working_dir,
+                )
+            )
+
+    return panes

--- a/src/ai_shell/tmux.py
+++ b/src/ai_shell/tmux.py
@@ -52,6 +52,8 @@ def build_claude_pane_command(
     extra_args: tuple[str, ...] = (),
     worktree_name: str | None = None,
     sync_deps: bool = True,
+    mcp_config_path: str | None = None,
+    team_env: bool = False,
 ) -> str:
     """Build the claude invocation string for a single tmux pane.
 
@@ -65,28 +67,50 @@ def build_claude_pane_command(
     When *sync_deps* is True (default), prepends ``uv sync`` / ``npm ci``
     commands so the per-repo venv is initialised before Claude starts.
 
+    When *mcp_config_path* is set, inserts ``--mcp-config <path>`` into the
+    claude argument list so the pane gets access to the MCP server.
+
+    When *team_env* is True, exports
+    ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`` so this pane runs in Agent
+    Teams mode.
+
     In non-safe mode, tries ``claude -c`` (continue previous conversation)
     first; falls back to a fresh session if that fails (e.g. no prior
     conversation exists).
     """
     uv_env = f"UV_PROJECT_ENVIRONMENT={uv_venv_path(repo_name, worktree_name)}"
 
+    env_exports = f"export {uv_env};"
+    if team_env:
+        env_exports += " export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1;"
+
     dep_prefix = _build_dep_sync_prefix() if sync_deps else ""
 
+    mcp_args: list[str] = []
+    if mcp_config_path:
+        mcp_args = ["--mcp-config", mcp_config_path]
+
     if safe:
-        parts: list[str] = ["claude", "-n", repo_name]
+        parts: list[str] = ["claude", *mcp_args, "-n", repo_name]
         if extra_args:
             parts.append("--")
             parts.extend(extra_args)
         cmd = " ".join(shlex.quote(p) for p in parts)
-        return f"export {uv_env}; {dep_prefix}{cmd}"
+        return f"{env_exports} {dep_prefix}{cmd}"
 
     # Non-safe: build two commands -- continue attempt and fresh fallback
-    base_parts: list[str] = ["claude", "--dangerously-skip-permissions", "-n", repo_name]
+    base_parts: list[str] = [
+        "claude",
+        "--dangerously-skip-permissions",
+        *mcp_args,
+        "-n",
+        repo_name,
+    ]
     continue_parts: list[str] = [
         "claude",
         "--dangerously-skip-permissions",
         "-c",
+        *mcp_args,
         "-n",
         repo_name,
     ]
@@ -98,7 +122,7 @@ def build_claude_pane_command(
     continue_cmd = " ".join(shlex.quote(p) for p in continue_parts) + extra_suffix
     fresh_cmd = " ".join(shlex.quote(p) for p in base_parts) + extra_suffix
 
-    return f"export {uv_env}; {dep_prefix}{continue_cmd} || {fresh_cmd}"
+    return f"{env_exports} {dep_prefix}{continue_cmd} || {fresh_cmd}"
 
 
 def build_check_session_command(container_name: str, session_name: str) -> list[str]:

--- a/tests/unit/test_interactive.py
+++ b/tests/unit/test_interactive.py
@@ -1,0 +1,507 @@
+"""Tests for the interactive multi-pane wizard and pane builder."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import click
+from click.testing import CliRunner
+
+from ai_shell.cli.__main__ import cli
+from ai_shell.interactive import (
+    InteractiveConfig,
+    PaneChoice,
+    PaneType,
+    _build_pane_options,
+    build_interactive_panes,
+    run_interactive_wizard,
+)
+
+# ── Test data ────────────────────────────────────────────────────────
+
+SAMPLE_WORKSPACE_REPOS = [
+    {"name": "repo-a", "path": "./repo-a", "repo_type": "service"},
+    {"name": "repo-b", "path": "./repo-b", "repo_type": "library"},
+]
+
+TEST_EXEC_ENV = {
+    "AWS_PROFILE": "",
+    "AWS_REGION": "us-east-1",
+    "AWS_DEFAULT_REGION": "us-east-1",
+    "AWS_PAGER": "",
+    "GH_TOKEN": "test-token",
+    "GITHUB_TOKEN": "test-token",
+    "IS_SANDBOX": "1",
+}
+
+WORKSPACE_YAML = """\
+workspace:
+  name: test-workspace
+  repos_dir: "."
+
+repos:
+  - name: repo-a
+    path: ./repo-a
+    repo_type: service
+  - name: repo-b
+    path: ./repo-b
+    repo_type: library
+"""
+
+
+def _no_existing_session(*args, **kwargs):
+    """subprocess.run side_effect: session check returns 1, everything else 0."""
+    result = MagicMock()
+    cmd = args[0] if args else kwargs.get("args", [])
+    if isinstance(cmd, list) and "has-session" in cmd:
+        result.returncode = 1
+    else:
+        result.returncode = 0
+    return result
+
+
+def _make_config_mock(project_name="test-project"):
+    config = MagicMock()
+    config.project_name = project_name
+    config.claude_provider = ""
+    config.bedrock_profile = ""
+    config.ai_profile = ""
+    config.aws_region = ""
+    config.extra_env = {}
+    config.project_dir = MagicMock()
+    config.local_chrome = False
+    return config
+
+
+# ── _build_pane_options ──────────────────────────────────────────────
+
+
+class TestBuildPaneOptions:
+    def test_no_workspace_repos(self):
+        options = _build_pane_options("my-project", None)
+        assert len(options) == 2
+        assert options[0].pane_type == PaneType.THIS_PROJECT
+        assert "my-project" in options[0].label
+        assert options[1].pane_type == PaneType.BASH
+
+    def test_empty_workspace_repos(self):
+        options = _build_pane_options("my-project", [])
+        assert len(options) == 2
+
+    def test_with_workspace_repos(self):
+        options = _build_pane_options("my-project", SAMPLE_WORKSPACE_REPOS)
+        assert len(options) == 4
+        assert options[0].pane_type == PaneType.THIS_PROJECT
+        assert options[1].pane_type == PaneType.BASH
+        assert options[2].pane_type == PaneType.WORKSPACE_REPO
+        assert options[2].repo_name == "repo-a"
+        assert options[2].repo_path == "./repo-a"
+        assert options[3].pane_type == PaneType.WORKSPACE_REPO
+        assert options[3].repo_name == "repo-b"
+
+    def test_workspace_repo_labels_include_type(self):
+        options = _build_pane_options("my-project", SAMPLE_WORKSPACE_REPOS)
+        assert "service" in options[2].label
+        assert "library" in options[3].label
+
+    def test_workspace_repo_without_type(self):
+        repos = [{"name": "plain-repo", "path": "./plain-repo"}]
+        options = _build_pane_options("my-project", repos)
+        assert options[2].label == "plain-repo"
+
+
+# ── run_interactive_wizard ───────────────────────────────────────────
+
+
+class TestRunInteractiveWizard:
+    def test_basic_two_worktree_panes(self):
+        # 2 windows, both "This project", no teams, no chrome
+        with patch("ai_shell.interactive.click") as mock_click:
+            mock_click.prompt.side_effect = [2, 1, 1]
+            mock_click.confirm.side_effect = [False, False]
+            mock_click.IntRange = click.IntRange
+            mock_click.Abort = click.Abort
+
+            result = run_interactive_wizard(project_name="my-project")
+
+        assert result is not None
+        assert len(result.pane_choices) == 2
+        assert all(c.pane_type == PaneType.THIS_PROJECT for c in result.pane_choices)
+        assert result.team_mode is False
+        assert result.shared_chrome is False
+
+    def test_mixed_panes_with_workspace(self):
+        # 3 windows: This project, Bash, repo-a
+        with patch("ai_shell.interactive.click") as mock_click:
+            mock_click.prompt.side_effect = [3, 1, 2, 3]
+            mock_click.confirm.side_effect = [True, True]
+            mock_click.IntRange = click.IntRange
+            mock_click.Abort = click.Abort
+
+            result = run_interactive_wizard(
+                project_name="my-project",
+                workspace_repos=SAMPLE_WORKSPACE_REPOS,
+            )
+
+        assert result is not None
+        assert len(result.pane_choices) == 3
+        assert result.pane_choices[0].pane_type == PaneType.THIS_PROJECT
+        assert result.pane_choices[1].pane_type == PaneType.BASH
+        assert result.pane_choices[2].pane_type == PaneType.WORKSPACE_REPO
+        assert result.pane_choices[2].repo_name == "repo-a"
+        assert result.team_mode is True
+        assert result.shared_chrome is True
+
+    def test_cancel_returns_none(self):
+        with patch("ai_shell.interactive.click") as mock_click:
+            mock_click.prompt.side_effect = KeyboardInterrupt
+            mock_click.Abort = click.Abort
+
+            result = run_interactive_wizard(project_name="my-project")
+
+        assert result is None
+
+    def test_eof_returns_none(self):
+        with patch("ai_shell.interactive.click") as mock_click:
+            mock_click.prompt.side_effect = EOFError
+            mock_click.Abort = click.Abort
+
+            result = run_interactive_wizard(project_name="my-project")
+
+        assert result is None
+
+
+# ── build_interactive_panes ──────────────────────────────────────────
+
+
+class TestBuildInteractivePanes:
+    def _mock_worktree(self, container_name, project_dir, wt_name):
+        return f"{project_dir}/.claude/worktrees/{wt_name}"
+
+    def test_this_project_creates_worktree_pane(self):
+        config = InteractiveConfig(
+            pane_choices=[PaneChoice(pane_type=PaneType.THIS_PROJECT)],
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=False,
+            extra_args=(),
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        assert len(panes) == 1
+        assert "my-project-wt-" in panes[0].name
+        assert ".claude/worktrees/" in panes[0].working_dir
+        assert "claude" in panes[0].command
+        assert "--dangerously-skip-permissions" in panes[0].command
+
+    def test_bash_pane(self):
+        config = InteractiveConfig(
+            pane_choices=[PaneChoice(pane_type=PaneType.BASH)],
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=False,
+            extra_args=(),
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        assert len(panes) == 1
+        assert panes[0].name == "bash-1"
+        assert panes[0].command == "/bin/bash"
+        assert panes[0].working_dir == "/root/projects/my-project"
+
+    def test_multiple_bash_panes_get_numbered(self):
+        config = InteractiveConfig(
+            pane_choices=[
+                PaneChoice(pane_type=PaneType.BASH),
+                PaneChoice(pane_type=PaneType.BASH),
+            ],
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=False,
+            extra_args=(),
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        assert panes[0].name == "bash-1"
+        assert panes[1].name == "bash-2"
+
+    def test_workspace_repo_pane(self):
+        config = InteractiveConfig(
+            pane_choices=[
+                PaneChoice(
+                    pane_type=PaneType.WORKSPACE_REPO,
+                    repo_name="repo-a",
+                    repo_path="./repo-a",
+                ),
+            ],
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-workspace",
+            container_name="test-container",
+            container_project_root="/root/projects/my-workspace",
+            safe=False,
+            extra_args=(),
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        assert len(panes) == 1
+        assert panes[0].name == "repo-a"
+        assert panes[0].working_dir == "/root/projects/my-workspace/repo-a"
+        assert "claude" in panes[0].command
+
+    def test_team_mode_only_on_first_claude_pane(self):
+        config = InteractiveConfig(
+            pane_choices=[
+                PaneChoice(pane_type=PaneType.BASH),
+                PaneChoice(pane_type=PaneType.THIS_PROJECT),
+                PaneChoice(
+                    pane_type=PaneType.WORKSPACE_REPO,
+                    repo_name="repo-a",
+                    repo_path="./repo-a",
+                ),
+            ],
+            team_mode=True,
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=False,
+            extra_args=(),
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        # Bash pane should have no team env
+        assert "AGENT_TEAMS" not in panes[0].command
+
+        # First Claude pane (THIS_PROJECT) should have team env
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1" in panes[1].command
+
+        # Second Claude pane (WORKSPACE_REPO) should NOT have team env
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in panes[2].command
+
+    def test_shared_chrome_adds_mcp_to_all_claude_panes(self):
+        config = InteractiveConfig(
+            pane_choices=[
+                PaneChoice(pane_type=PaneType.THIS_PROJECT),
+                PaneChoice(pane_type=PaneType.BASH),
+                PaneChoice(
+                    pane_type=PaneType.WORKSPACE_REPO,
+                    repo_name="repo-a",
+                    repo_path="./repo-a",
+                ),
+            ],
+            shared_chrome=True,
+        )
+        mcp_path = "/etc/ai-shell/chrome-mcp.json"
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=False,
+            extra_args=(),
+            mcp_config_path=mcp_path,
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        # Claude panes should have MCP config
+        assert "--mcp-config" in panes[0].command
+        assert mcp_path in panes[0].command
+        assert "--mcp-config" in panes[2].command
+
+        # Bash pane should not
+        assert "--mcp-config" not in panes[1].command
+
+    def test_safe_mode_propagated(self):
+        config = InteractiveConfig(
+            pane_choices=[PaneChoice(pane_type=PaneType.THIS_PROJECT)],
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=True,
+            extra_args=(),
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        assert "--dangerously-skip-permissions" not in panes[0].command
+        assert "||" not in panes[0].command
+
+    def test_no_chrome_no_mcp_args(self):
+        config = InteractiveConfig(
+            pane_choices=[PaneChoice(pane_type=PaneType.THIS_PROJECT)],
+            shared_chrome=False,
+        )
+        panes = build_interactive_panes(
+            config=config,
+            project_name="my-project",
+            container_name="test-container",
+            container_project_root="/root/projects/my-project",
+            safe=False,
+            extra_args=(),
+            mcp_config_path="/etc/ai-shell/chrome-mcp.json",
+            setup_worktree_fn=self._mock_worktree,
+        )
+
+        # shared_chrome=False means mcp_config_path should not be passed through
+        assert "--mcp-config" not in panes[0].command
+
+
+# ── CLI integration ──────────────────────────────────────────────────
+
+
+class TestInteractiveCLI:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_interactive_requires_multi(self):
+        result = self.runner.invoke(cli, ["claude", "--interactive"])
+        assert result.exit_code != 0
+        assert "--interactive requires --multi" in result.output
+
+    def test_interactive_conflicts_with_team(self):
+        result = self.runner.invoke(cli, ["claude", "--multi", "--interactive", "--team"])
+        assert result.exit_code != 0
+        assert "incompatible" in result.output
+
+    def test_interactive_conflicts_with_local_chrome(self):
+        result = self.runner.invoke(cli, ["claude", "--multi", "--interactive", "--local-chrome"])
+        assert result.exit_code != 0
+        assert "incompatible" in result.output
+
+    @patch("ai_shell.cli.commands.tools.subprocess.run")
+    @patch("ai_shell.cli.commands.tools.dev_container_name", return_value="test-container")
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    def test_interactive_multi_launches_wizard(
+        self,
+        mock_config,
+        mock_manager_cls,
+        mock_build_env,
+        mock_check_bedrock,
+        mock_dev_name,
+        mock_subprocess,
+    ):
+        """--multi --interactive runs the wizard and launches tmux."""
+        mock_config.return_value = _make_config_mock()
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "test-container"
+        mock_manager_cls.return_value = mock_manager
+        mock_subprocess.side_effect = _no_existing_session
+
+        with self.runner.isolated_filesystem():
+            # 2 windows, both "This project", no teams, no chrome
+            self.runner.invoke(
+                cli,
+                ["claude", "--multi", "--interactive"],
+                input="2\n1\n1\nn\nn\n",
+            )
+
+        # Should have called tmux attach-session
+        attach_calls = [
+            call
+            for call in mock_subprocess.call_args_list
+            if any("attach-session" in str(a) for a in call[0])
+        ]
+        assert len(attach_calls) >= 1
+
+    @patch("ai_shell.interactive.run_interactive_wizard", return_value=None)
+    @patch("ai_shell.cli.commands.tools.subprocess.run")
+    @patch("ai_shell.cli.commands.tools.dev_container_name", return_value="test-container")
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    def test_interactive_cancel_exits_cleanly(
+        self,
+        mock_config,
+        mock_manager_cls,
+        mock_build_env,
+        mock_check_bedrock,
+        mock_dev_name,
+        mock_subprocess,
+        mock_wizard,
+    ):
+        """Cancelling the wizard exits without launching tmux."""
+        mock_config.return_value = _make_config_mock()
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "test-container"
+        mock_manager_cls.return_value = mock_manager
+        mock_subprocess.side_effect = _no_existing_session
+
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(
+                cli,
+                ["claude", "--multi", "--interactive"],
+            )
+
+        # Should NOT have tried tmux attach
+        attach_calls = [
+            call
+            for call in mock_subprocess.call_args_list
+            if any("attach-session" in str(a) for a in call[0])
+        ]
+        assert len(attach_calls) == 0
+
+    @patch("ai_shell.cli.commands.tools.subprocess.run")
+    @patch("ai_shell.cli.commands.tools.dev_container_name", return_value="test-container")
+    @patch("ai_shell.cli.commands.tools._check_bedrock_access")
+    @patch("ai_shell.cli.commands.tools.build_dev_environment")
+    @patch("ai_shell.cli.commands.tools.ContainerManager")
+    @patch("ai_shell.cli.commands.tools.load_config")
+    def test_interactive_with_workspace_shows_repo_options(
+        self,
+        mock_config,
+        mock_manager_cls,
+        mock_build_env,
+        mock_check_bedrock,
+        mock_dev_name,
+        mock_subprocess,
+    ):
+        """With workspace.yaml, subrepos appear as options."""
+        mock_config.return_value = _make_config_mock()
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "test-container"
+        mock_manager_cls.return_value = mock_manager
+        mock_subprocess.side_effect = _no_existing_session
+
+        with self.runner.isolated_filesystem():
+            with open("workspace.yaml", "w") as f:
+                f.write(WORKSPACE_YAML)
+
+            # 2 windows: repo-a (option 3) and Bash (option 2), no teams, no chrome
+            self.runner.invoke(
+                cli,
+                ["claude", "--multi", "--interactive"],
+                input="2\n3\n2\nn\nn\n",
+            )
+
+        # tmux commands should have been issued
+        tmux_calls = [
+            call
+            for call in mock_subprocess.call_args_list
+            if any("tmux" in str(a) for a in call[0])
+        ]
+        assert len(tmux_calls) >= 1

--- a/tests/unit/test_multi.py
+++ b/tests/unit/test_multi.py
@@ -128,6 +128,54 @@ class TestBuildClaudePaneCommand:
         assert "UV_PROJECT_ENVIRONMENT=/root/.cache/uv/venvs/my-repo;" in cmd
         assert "-wt-" not in cmd
 
+    def test_mcp_config_path_in_command(self):
+        cmd = build_claude_pane_command(
+            repo_name="my-repo", mcp_config_path="/etc/ai-shell/chrome-mcp.json"
+        )
+        assert "--mcp-config" in cmd
+        assert "/etc/ai-shell/chrome-mcp.json" in cmd
+
+    def test_mcp_config_path_in_both_retry_branches(self):
+        cmd = build_claude_pane_command(
+            repo_name="my-repo", mcp_config_path="/etc/ai-shell/chrome-mcp.json"
+        )
+        parts = cmd.split("||")
+        assert "--mcp-config" in parts[0]
+        assert "--mcp-config" in parts[1]
+
+    def test_mcp_config_path_in_safe_mode(self):
+        cmd = build_claude_pane_command(
+            repo_name="my-repo", safe=True, mcp_config_path="/etc/ai-shell/chrome-mcp.json"
+        )
+        assert "--mcp-config" in cmd
+        assert "/etc/ai-shell/chrome-mcp.json" in cmd
+
+    def test_mcp_config_path_none_no_flag(self):
+        cmd = build_claude_pane_command(repo_name="my-repo", mcp_config_path=None)
+        assert "--mcp-config" not in cmd
+
+    def test_team_env_exports_agent_teams(self):
+        cmd = build_claude_pane_command(repo_name="my-repo", team_env=True)
+        assert "export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1;" in cmd
+
+    def test_team_env_false_no_agent_teams(self):
+        cmd = build_claude_pane_command(repo_name="my-repo", team_env=False)
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in cmd
+
+    def test_team_env_with_safe_mode(self):
+        cmd = build_claude_pane_command(repo_name="my-repo", safe=True, team_env=True)
+        assert "export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1;" in cmd
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_mcp_and_team_combined(self):
+        cmd = build_claude_pane_command(
+            repo_name="my-repo",
+            mcp_config_path="/etc/ai-shell/chrome-mcp.json",
+            team_env=True,
+        )
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1" in cmd
+        assert "--mcp-config" in cmd
+
 
 class TestPaneSpec:
     def test_construction(self):


### PR DESCRIPTION
## Summary
- Add `--interactive/-i` flag to `claude --multi` for a guided wizard that lets you configure each tmux pane individually: Claude worktrees, bash shells, or workspace subrepos
- Pre-launch toggles for Agent Teams mode (primary Claude pane) and shared Chrome DevTools MCP across all Claude panes
- Extend `build_claude_pane_command` with `mcp_config_path` and `team_env` params for Chrome and teams support in tmux panes
- Local Chrome bridge: proxy Chrome DevTools Protocol from host Windows Chrome into the dev container via `--local-chrome` flag

## Test plan
- [x] 95 unit tests pass (23 new in `test_interactive.py`, 9 new in `test_multi.py`)
- [x] Full suite: 397 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Manual: `ai-shell claude --multi -i` in single-repo dir (no workspace.yaml) -- "This project" + "Bash" options
- [ ] Manual: `ai-shell claude --multi -i` in workspace dir -- subrepo options appear
- [ ] Manual: `ai-shell claude --local-chrome` -- Chrome DevTools MCP attached