### PR TITLE
fix: prefer SSO keyring token over PAT in container entrypoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,22 @@ git config --global init.defaultBranch main
 git config --global color.ui auto
 git config --global core.editor vim
 
+# Prefer SSO keyring token over the env-var PAT.
+# When ~/.config/gh is mounted, the SSO token carries org-level access that a PAT
+# scoped to a personal account may lack (e.g. private marketplace plugins in augmenting-integrations).
+_SAVED_GH_TOKEN="${GH_TOKEN:-}"
+unset GH_TOKEN GITHUB_TOKEN
+_SSO_TOKEN=$(gh auth token --hostname github.com 2>/dev/null || true)
+if [ -n "$_SSO_TOKEN" ]; then
+    export GH_TOKEN="$_SSO_TOKEN"
+    export GITHUB_TOKEN="$_SSO_TOKEN"
+else
+    # No keyring token — fall back to the PAT passed via env
+    [ -n "$_SAVED_GH_TOKEN" ] && export GH_TOKEN="$_SAVED_GH_TOKEN"
+    [ -n "$_SAVED_GH_TOKEN" ] && export GITHUB_TOKEN="$_SAVED_GH_TOKEN"
+fi
+unset _SAVED_GH_TOKEN _SSO_TOKEN
+
 # Configure Git to use GitHub CLI for authentication if token is present
 if [ -n "$GH_TOKEN" ]; then
     git config --global credential.https://github.com.helper "!gh auth git-credential"


### PR DESCRIPTION
## Summary

- On container startup, temporarily unsets `GH_TOKEN`/`GITHUB_TOKEN` so `gh auth token` queries the keyring rather than reflecting the env var back
- If a keyring/SSO token is found, it replaces the PAT as `GH_TOKEN`/`GITHUB_TOKEN` for the rest of the session
- Falls back to the original PAT when no keyring token is present (CI, no `~/.config/gh` mounted, unauthenticated)

## Motivation

The `augmenting-integrations/ai-cc-tools` Claude Code marketplace plugin works on org projects but fails on personal-account projects. Root cause: `GH_TOKEN` is a PAT that may not carry SSO authorization for the org's private repos. The SSO OAuth token stored in `~/.config/gh` (already bind-mounted into every dev container) has the necessary org-level scopes.

## Test plan

- [ ] Restart a dev container for a **personal-account** project; run `gh auth status` inside — should show SSO-authenticated identity with org scopes
- [ ] Confirm `gh repo view augmenting-integrations/ai-cc-tools` succeeds inside the container
- [ ] Confirm fallback: temporarily rename `~/.config/gh` on host, restart container — `GH_TOKEN` PAT should be used instead
- [ ] `uv run pytest tests/unit/` passes (no test changes needed)