### PR TITLE
feat: swap qwen3-coder-next for Qwen3-Coder-32B A3B and add Llama 3.3 Abliterated

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ image_tag = "latest"
 extra_env = { MY_VAR = "value" }
 
 [llm]
-primary_model = "qwen3.5:27b"
-fallback_model = "qwen3-coder-next"
+primary_model = "qwen3-coder:32b-a3b-q4_K_M"
+fallback_model = "qwen3.5:27b"
 context_size = 32768
 ollama_port = 11434
 webui_port = 3000

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "ollama/qwen3-coder-next",
+  "model": "ollama/qwen3-coder:32b-a3b-q4_K_M",
   "provider": {
     "ollama": {
       "npm": "@ai-sdk/openai-compatible",
@@ -12,8 +12,11 @@
         "qwen3.5:27b": {
           "name": "Qwen 3.5 27B (Local)"
         },
-        "qwen3-coder-next": {
-          "name": "Qwen3 Coder Next 80B MoE (Local)"
+        "qwen3-coder:32b-a3b-q4_K_M": {
+          "name": "Qwen3-Coder-32B A3B (Local)"
+        },
+        "huihui_ai/llama3.3-abliterated": {
+          "name": "Llama 3.3 70B Abliterated (Local)"
         }
       }
     },

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -53,7 +53,7 @@ WEBUI_DATA_VOLUME = "augint-shell-webui-data"
 # =============================================================================
 OLLAMA_IMAGE = "ollama/ollama"
 WEBUI_IMAGE = "ghcr.io/open-webui/open-webui:main"
-DEFAULT_PRIMARY_MODEL = "qwen3-coder-next"
+DEFAULT_PRIMARY_MODEL = "qwen3-coder:32b-a3b-q4_K_M"
 DEFAULT_FALLBACK_MODEL = "qwen3.5:27b"
 DEFAULT_CONTEXT_SIZE = 32768
 DEFAULT_OLLAMA_PORT = 11434

--- a/src/ai_shell/templates/ai-shell.yaml
+++ b/src/ai_shell/templates/ai-shell.yaml
@@ -111,20 +111,23 @@
 #
 # Uncensored / instruction-following variants
 # ────────────────────────────────────────────
-# dolphin3:8b                  ~5 GiB   Dolphin 3.0 (uncensored Llama 3.1 8B)
-# llama3.1:8b                  ~5 GiB   Meta Llama 3.1 8B instruct
-# llama3.1:8b-instruct-q4_k_m  ~5 GiB   Q4_K_M quantized
-# llama3.2:latest              ~2 GiB   Meta Llama 3.2 3B (fast/small)
+# dolphin3:8b                      ~5 GiB   Dolphin 3.0 (uncensored Llama 3.1 8B)
+# huihui_ai/llama3.3-abliterated   ~16 GiB  Llama 3.3 70B abliterated (uncensored chat)
+# llama3.1:8b                      ~5 GiB   Meta Llama 3.1 8B instruct
+# llama3.1:8b-instruct-q4_k_m      ~5 GiB   Q4_K_M quantized
+# llama3.2:latest                  ~2 GiB   Meta Llama 3.2 3B (fast/small)
 #
 # Coding-heavy models
 # ────────────────────
-# qwen2.5-coder:32b-q4_k_m    ~19 GiB  Q4_K_M  top coding quality on 4090
-# qwen3:14b-q4_k_m             ~9 GiB   Q4_K_M  fast coder with good accuracy
-# qwen3:32b-q4_k_m             ~19 GiB  Q4_K_M  best local coding on 4090
-# qwen3-coder-next             custom   80B MoE loaded via custom Modelfile
+# qwen2.5-coder:32b-q4_k_m        ~19 GiB  Q4_K_M  top coding quality on 4090
+# qwen3:14b-q4_k_m               ~9 GiB   Q4_K_M  fast coder with good accuracy
+# qwen3:32b-q4_k_m               ~19 GiB  Q4_K_M  best local coding on 4090
+# qwen3-coder:32b-a3b-q4_K_M     ~12-14 GiB  Q4_K_M  Qwen3-Coder-32B A3B (Mixture-of-Experts)
 #
 # Quick-start pull commands (run inside `ai-shell llm shell`):
 #   ollama pull qwen3.5:27b
+#   ollama pull qwen3-coder:32b-a3b-q4_K_M
+#   ollama pull huihui_ai/llama3.3-abliterated
 #   ollama pull dolphin3:8b
 #   ollama pull llama3.1:8b
 #   ollama pull qwen2.5-coder:32b-q4_k_m
@@ -153,7 +156,7 @@
 #   ai-shell llm setup        # pulls models + applies context-window config
 #
 # llm:
-#   primary_model: qwen3-coder-next
+#   primary_model: qwen3-coder:32b-a3b-q4_K_M
 #   fallback_model: qwen3.5:27b
 #   context_size: 32768
 #   ollama_port: 11434

--- a/tests/unit/test_cli_llm.py
+++ b/tests/unit/test_cli_llm.py
@@ -91,7 +91,7 @@ class TestLlmCommands:
         config = MagicMock()
         config.ollama_port = 11434
         config.webui_port = 3000
-        config.primary_model = "qwen3-coder-next"
+        config.primary_model = "qwen3-coder:32b-a3b-q4_K_M"
         config.fallback_model = "qwen3.5:27b"
         config.context_size = 32768
         mock_config.return_value = config
@@ -110,14 +110,14 @@ class TestLlmCommands:
         assert "http://localhost:11434/v1" in result.output
         assert "http://localhost:3000" in result.output
         assert "Chat interface" in result.output
-        assert "qwen3-coder-next" in result.output
+        assert "qwen3-coder:32b-a3b-q4_K_M" in result.output
         assert "32768" in result.output
 
     def test_llm_status_not_found(self, mock_config, mock_manager_cls):
         config = MagicMock()
         config.ollama_port = 11434
         config.webui_port = 3000
-        config.primary_model = "qwen3-coder-next"
+        config.primary_model = "qwen3-coder:32b-a3b-q4_K_M"
         config.fallback_model = "qwen3.5:27b"
         config.context_size = 32768
         mock_config.return_value = config
@@ -137,7 +137,7 @@ class TestLlmCommands:
 
     def test_llm_pull(self, mock_config, mock_manager_cls):
         config = MagicMock()
-        config.primary_model = "qwen3-coder-next"
+        config.primary_model = "qwen3-coder:32b-a3b-q4_K_M"
         config.fallback_model = "qwen3.5:27b"
         mock_config.return_value = config
 

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -378,7 +378,7 @@ class TestToolCommands:
     ):
         mock_build_env.return_value = dict(TEST_EXEC_ENV)
         config = MagicMock()
-        config.primary_model = "qwen3-coder-next"
+        config.primary_model = "qwen3-coder:32b-a3b-q4_K_M"
         config.ollama_port = 11434
         mock_config.return_value = config
 
@@ -395,7 +395,7 @@ class TestToolCommands:
         extra_env = call_args[1].get("extra_env", {})
 
         assert "--model" in cmd
-        assert "ollama_chat/qwen3-coder-next" in cmd
+        assert "ollama_chat/qwen3-coder:32b-a3b-q4_K_M" in cmd
         assert "--yes-always" in cmd
         assert extra_env["OLLAMA_API_BASE"] == "http://host.docker.internal:11434"
         assert extra_env["GH_TOKEN"] == "test-token"
@@ -405,7 +405,7 @@ class TestToolCommands:
     ):
         mock_build_env.return_value = dict(TEST_EXEC_ENV)
         config = MagicMock()
-        config.primary_model = "qwen3-coder-next"
+        config.primary_model = "qwen3-coder:32b-a3b-q4_K_M"
         config.ollama_port = 11434
         mock_config.return_value = config
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,7 @@ class TestAiShellConfig:
     def test_defaults(self):
         config = AiShellConfig()
         assert config.image == "svange/augint-shell"
-        assert config.primary_model == "qwen3-coder-next"
+        assert config.primary_model == "qwen3-coder:32b-a3b-q4_K_M"
         assert config.ollama_port == 11434
         assert config.webui_port == 3000
 


### PR DESCRIPTION
## Summary
- Replace deprecated `qwen3-coder-next` with `qwen3-coder:32b-a3b-q4_K_M` as the primary coding model (Qwen3-Coder-32B A3B MoE, 3B active params, 50.3% SWE-Bench Verified, ~12-14 GiB Q4_K_M)
- Add `huihui_ai/llama3.3-abliterated` as an uncensored chat option (Llama 3.3 70B abliterated, ~16 GiB Q3_K_M)
- `qwen3.5:27b` remains the general-purpose fallback

Updates defaults, config templates, `opencode.json`, README, and tests. Closes #77.

## Test plan
- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest --cov=src --cov-fail-under=80` (85.90% coverage)
- [ ] CI pipeline passes