### PR TITLE
feat(shell): rename bash subcommand to shell, add zsh/fish support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -136,43 +136,49 @@ WORKDIR /root/projects/${PROJECT_DIR}
 # Switch to root and configure environment
 USER root
 
-# Set up root's bash environment with useful aliases and settings
-RUN echo '# Useful aliases' >> /root/.bashrc && \
-    echo 'alias ll="ls -la"' >> /root/.bashrc && \
-    echo 'alias la="ls -A"' >> /root/.bashrc && \
-    echo 'alias l="ls -CF"' >> /root/.bashrc && \
-    echo 'alias ..="cd .."' >> /root/.bashrc && \
-    echo 'alias ...="cd ../.."' >> /root/.bashrc && \
-    echo 'alias gs="git status"' >> /root/.bashrc && \
-    echo 'alias gd="git diff"' >> /root/.bashrc && \
-    echo 'alias gl="git log --oneline -10"' >> /root/.bashrc && \
-    echo 'alias dc="docker compose"' >> /root/.bashrc && \
-    echo '' >> /root/.bashrc && \
-    echo '# Environment settings' >> /root/.bashrc && \
-    echo 'export EDITOR=vim' >> /root/.bashrc && \
-    echo 'export HISTSIZE=10000' >> /root/.bashrc && \
-    echo 'export HISTFILESIZE=20000' >> /root/.bashrc && \
-    echo 'export HISTCONTROL=ignoreboth:erasedups' >> /root/.bashrc && \
-    echo '' >> /root/.bashrc && \
-    echo '# Better prompt showing git branch' >> /root/.bashrc && \
-    echo 'parse_git_branch() {' >> /root/.bashrc && \
-    echo '    git branch 2> /dev/null | sed -e "/^[^*]/d" -e "s/* \(.*\)/ (\1)/"' >> /root/.bashrc && \
-    echo '}' >> /root/.bashrc && \
-    echo 'export PS1="\[\033[01;31m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[33m\]\$(parse_git_branch)\[\033[00m\]\$ "' >> /root/.bashrc && \
-    echo '' >> /root/.bashrc && \
-    echo '# Useful functions' >> /root/.bashrc && \
-    echo 'mkcd() { mkdir -p "$1" && cd "$1"; }' >> /root/.bashrc && \
-    echo 'extract() {' >> /root/.bashrc && \
-    echo '    if [ -f "$1" ]; then' >> /root/.bashrc && \
-    echo '        case "$1" in' >> /root/.bashrc && \
-    echo '            *.tar.bz2) tar xjf "$1" ;;' >> /root/.bashrc && \
-    echo '            *.tar.gz) tar xzf "$1" ;;' >> /root/.bashrc && \
-    echo '            *.tar) tar xf "$1" ;;' >> /root/.bashrc && \
-    echo '            *.zip) unzip "$1" ;;' >> /root/.bashrc && \
-    echo '            *) echo "Unknown archive format" ;;' >> /root/.bashrc && \
-    echo '        esac' >> /root/.bashrc && \
-    echo '    fi' >> /root/.bashrc && \
-    echo '}' >> /root/.bashrc
+# Install zsh, fish, and bash-completion for multi-shell support
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    zsh \
+    fish \
+    bash-completion \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Starship (cross-shell prompt, used by bash/zsh/fish)
+RUN curl -sS https://starship.rs/install.sh | sh -s -- --yes --bin-dir /usr/local/bin
+
+# Install Oh My Zsh (unattended) + popular plugins
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended && \
+    git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
+        /root/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
+    git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
+        /root/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && \
+    git clone --depth=1 https://github.com/zsh-users/zsh-completions \
+        /root/.oh-my-zsh/custom/plugins/zsh-completions
+
+# Install Fisher (fish plugin manager) + popular plugins
+RUN mkdir -p /root/.config/fish/functions /root/.config/fish/completions /root/.config/fish/conf.d && \
+    curl -sSL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish \
+        -o /root/.config/fish/functions/fisher.fish && \
+    fish -c "fisher install jorgebucaran/fisher jorgebucaran/autopair.fish PatrickF1/fzf.fish" || true
+
+# Install Oh My Tmux (gpakosz/.tmux)
+RUN git clone --depth=1 https://github.com/gpakosz/.tmux.git /root/.tmux && \
+    ln -sf /root/.tmux/.tmux.conf /root/.tmux.conf
+
+# Install vim-plug
+RUN curl -fLo /root/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+
+# Copy shell configs into place
+COPY shell-configs/bashrc /root/.bashrc
+COPY shell-configs/zshrc /root/.zshrc
+COPY shell-configs/fish-config.fish /root/.config/fish/config.fish
+COPY shell-configs/starship.toml /root/.config/starship.toml
+COPY shell-configs/vimrc /root/.vimrc
+COPY shell-configs/tmux.conf.local /root/.tmux.conf.local
+
+# Pre-install vim plugins headlessly so first launch is instant
+RUN vim -es -u /root/.vimrc -i NONE -c "PlugInstall --sync" -c "qa" || true
 
 # Install additional useful development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -214,14 +220,6 @@ RUN git config --global --add safe.directory '*' && \
     # Disable git hooks in container - AI tools commit frequently; pre-commit is run explicitly
     git config --global core.hooksPath /dev/null && \
     git config --global --unset-all http.sslbackend || true
-
-# Set up vim with basic config
-RUN echo 'set number' >> /root/.vimrc && \
-    echo 'set autoindent' >> /root/.vimrc && \
-    echo 'set expandtab' >> /root/.vimrc && \
-    echo 'set tabstop=4' >> /root/.vimrc && \
-    echo 'set shiftwidth=4' >> /root/.vimrc && \
-    echo 'syntax on' >> /root/.vimrc
 
 # Note: Running as root to avoid Windows/Docker permission issues
 # The docker-compose.yml should NOT specify user: "1000:1000"

--- a/docker/shell-configs/bashrc
+++ b/docker/shell-configs/bashrc
@@ -1,0 +1,105 @@
+# ~/.bashrc -- interactive shell config
+case $- in *i*) ;; *) return;; esac
+
+# ---------- History ----------
+HISTCONTROL=ignoreboth:erasedups
+HISTSIZE=100000
+HISTFILESIZE=200000
+HISTTIMEFORMAT="%F %T "
+shopt -s histappend
+shopt -s cmdhist
+PROMPT_COMMAND="history -a; history -n; ${PROMPT_COMMAND}"
+
+# ---------- Shell options ----------
+shopt -s checkwinsize
+shopt -s globstar 2>/dev/null
+shopt -s autocd 2>/dev/null
+shopt -s cdspell 2>/dev/null
+shopt -s dirspell 2>/dev/null
+
+# ---------- Environment ----------
+export CLICOLOR=1
+export LESS='-R -i -M -w -z-4'
+export PAGER=less
+export EDITOR=vim
+
+# ---------- Colors ----------
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+    alias diff='diff --color=auto'
+    alias ip='ip -color=auto'
+fi
+
+# ---------- Aliases ----------
+alias ll='ls -alhF'
+alias la='ls -A'
+alias l='ls -CF'
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+alias h='history'
+alias gs='git status -sb'
+alias gd='git diff'
+alias gdc='git diff --cached'
+alias gco='git checkout'
+alias gcm='git commit -m'
+alias gp='git push'
+alias gl='git pull'
+alias glog='git log --oneline --graph --decorate --all'
+alias gb='git branch'
+alias ga='git add'
+alias dc='docker compose'
+
+# ---------- Functions ----------
+mkcd() { mkdir -p "$1" && cd "$1"; }
+extract() {
+    if [ -f "$1" ]; then
+        case "$1" in
+            *.tar.bz2) tar xjf "$1" ;;
+            *.tar.gz)  tar xzf "$1" ;;
+            *.tar.xz)  tar xJf "$1" ;;
+            *.tar)     tar xf  "$1" ;;
+            *.tbz2)    tar xjf "$1" ;;
+            *.tgz)     tar xzf "$1" ;;
+            *.zip)     unzip   "$1" ;;
+            *.gz)      gunzip  "$1" ;;
+            *.bz2)     bunzip2 "$1" ;;
+            *)         echo "Unknown archive format: $1" ;;
+        esac
+    fi
+}
+
+# ---------- Completion ----------
+if ! shopt -oq posix; then
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+        . /usr/share/bash-completion/bash_completion
+    elif [ -f /etc/bash_completion ]; then
+        . /etc/bash_completion
+    fi
+fi
+
+# ---------- fzf ----------
+if [ -f /usr/share/doc/fzf/examples/key-bindings.bash ]; then
+    . /usr/share/doc/fzf/examples/key-bindings.bash
+fi
+if [ -f /usr/share/doc/fzf/examples/completion.bash ]; then
+    . /usr/share/doc/fzf/examples/completion.bash
+fi
+
+# ---------- Prompt ----------
+if command -v starship >/dev/null 2>&1; then
+    eval "$(starship init bash)"
+else
+    # Fallback with git branch
+    __git_branch() {
+        git branch 2>/dev/null | sed -n 's/^\* \(.*\)/ (\1)/p'
+    }
+    PS1='\[\e[1;31m\]\u@\h\[\e[0m\]:\[\e[1;34m\]\w\[\e[0;33m\]$(__git_branch)\[\e[0m\]\$ '
+fi
+
+# ---------- Local overrides ----------
+[ -f ~/.bashrc.local ] && . ~/.bashrc.local

--- a/docker/shell-configs/fish-config.fish
+++ b/docker/shell-configs/fish-config.fish
@@ -1,0 +1,50 @@
+# ~/.config/fish/config.fish
+
+if status is-interactive
+    # ---------- Environment ----------
+    set -gx EDITOR vim
+    set -gx PAGER less
+    set -gx LESS '-R -i -M -w -z-4'
+    set -gx CLICOLOR 1
+
+    # ---------- Greeting ----------
+    set -g fish_greeting ""
+
+    # ---------- Aliases ----------
+    alias ll 'ls -alhF --color=auto'
+    alias la 'ls -A --color=auto'
+    alias l  'ls -CF --color=auto'
+    alias grep 'grep --color=auto'
+
+    # Navigation
+    alias ..  'cd ..'
+    alias ... 'cd ../..'
+    alias .... 'cd ../../..'
+
+    # Git
+    alias gs 'git status -sb'
+    alias gd 'git diff'
+    alias gdc 'git diff --cached'
+    alias gco 'git checkout'
+    alias gcm 'git commit -m'
+    alias gp 'git push'
+    alias gl 'git pull'
+    alias glog 'git log --oneline --graph --decorate --all'
+    alias gb 'git branch'
+    alias ga 'git add'
+
+    # Docker
+    alias dc 'docker compose'
+
+    # ---------- fzf.fish key-bindings auto-register from the plugin ----------
+
+    # ---------- Prompt ----------
+    if type -q starship
+        starship init fish | source
+    end
+
+    # ---------- Local overrides ----------
+    if test -f ~/.config/fish/config.local.fish
+        source ~/.config/fish/config.local.fish
+    end
+end

--- a/docker/shell-configs/starship.toml
+++ b/docker/shell-configs/starship.toml
@@ -1,0 +1,70 @@
+# Starship config -- ASCII-friendly glyphs (no Nerd Font required)
+# Docs: https://starship.rs/config/
+
+format = """
+[>>](bold blue) $username$hostname$directory$git_branch$git_status$python$nodejs$rust$golang$docker_context$cmd_duration
+$character """
+
+add_newline = false
+command_timeout = 1000
+
+[character]
+success_symbol = "[>](bold green)"
+error_symbol = "[x](bold red)"
+vicmd_symbol = "[<](bold yellow)"
+
+[username]
+style_user = "bold cyan"
+style_root = "bold red"
+format = "[$user]($style)"
+show_always = true
+
+[hostname]
+ssh_only = false
+format = "@[$hostname](bold purple) "
+disabled = false
+
+[directory]
+style = "bold blue"
+truncation_length = 4
+truncate_to_repo = true
+format = "in [$path]($style) "
+
+[git_branch]
+symbol = "git:"
+style = "bold yellow"
+format = "on [$symbol$branch]($style) "
+
+[git_status]
+style = "bold red"
+format = '([\[$all_status$ahead_behind\]]($style) )'
+conflicted = "!"
+ahead = ">"
+behind = "<"
+diverged = "<>"
+untracked = "?"
+stashed = "$"
+modified = "*"
+staged = "+"
+renamed = "r"
+deleted = "x"
+
+[cmd_duration]
+min_time = 2_000
+format = "took [$duration](bold yellow) "
+
+[python]
+symbol = "py:"
+format = 'via [${symbol}${pyv}(\($virtualenv\) )]($style)'
+
+[nodejs]
+symbol = "node:"
+
+[rust]
+symbol = "rust:"
+
+[golang]
+symbol = "go:"
+
+[docker_context]
+symbol = "docker:"

--- a/docker/shell-configs/tmux.conf.local
+++ b/docker/shell-configs/tmux.conf.local
@@ -1,0 +1,55 @@
+# ~/.tmux.conf.local -- overlays on gpakosz/.tmux defaults.
+#
+# The ai-shell multi-Claude launcher sets session-scoped options (prefix C-a,
+# mouse on, status style, pane-border-status top with amber/mauve) using
+# `set-option -t <session>`. Those per-session values take precedence over
+# anything set here, so this file is safe for interactive single-session use.
+
+# ---------- Key bindings ----------
+# Default prefix (C-b) kept globally; the app switches to C-a per-session.
+
+# Reload config
+bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
+
+# Vi-style pane navigation with prefix + h/j/k/l
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Split panes using | and - (keep current path)
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# ---------- General ----------
+tmux_conf_copy_to_os_clipboard=true
+set -g mouse on
+set -g history-limit 50000
+set -g base-index 1
+set -g pane-base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+set -g escape-time 10
+set -g focus-events on
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",xterm-256color:Tc,alacritty:Tc,*:RGB"
+
+# ---------- gpakosz theme toggles ----------
+tmux_conf_theme_24b_colour=true
+tmux_conf_theme_window_fg="default"
+tmux_conf_theme_window_bg="default"
+
+# Keep pane-border-status off globally; the app turns it on per-session.
+set -g pane-border-status off
+set -g pane-border-lines single
+
+# ---------- Copy-mode ----------
+setw -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel
+
+# ---------- Activity ----------
+set -g monitor-activity on
+set -g visual-activity off

--- a/docker/shell-configs/vimrc
+++ b/docker/shell-configs/vimrc
@@ -1,0 +1,99 @@
+" ~/.vimrc -- sensible defaults + vim-plug
+
+" ---------- Plugins ----------
+call plug#begin('~/.vim/plugged')
+Plug 'tpope/vim-sensible'
+Plug 'tpope/vim-surround'
+Plug 'tpope/vim-commentary'
+Plug 'tpope/vim-fugitive'
+Plug 'tpope/vim-repeat'
+Plug 'airblade/vim-gitgutter'
+Plug 'itchyny/lightline.vim'
+Plug 'preservim/nerdtree'
+Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
+Plug 'junegunn/fzf.vim'
+Plug 'morhetz/gruvbox'
+call plug#end()
+
+" ---------- Basics ----------
+set nocompatible
+syntax on
+filetype plugin indent on
+set number
+set relativenumber
+set cursorline
+set ruler
+set showcmd
+set showmatch
+set wildmenu
+set wildmode=longest:full,full
+set mouse=a
+if has('mouse_sgr')
+    set ttymouse=sgr
+endif
+set termguicolors
+set t_Co=256
+set background=dark
+set encoding=utf-8
+set fileencoding=utf-8
+set hidden
+set scrolloff=5
+set sidescrolloff=8
+set laststatus=2
+set noshowmode
+set clipboard=unnamedplus
+set updatetime=300
+set signcolumn=yes
+set backspace=indent,eol,start
+set nowrap
+set list
+set listchars=tab:>-,trail:.,extends:>,precedes:<,nbsp:+
+
+" ---------- Search ----------
+set ignorecase
+set smartcase
+set incsearch
+set hlsearch
+
+" ---------- Indentation ----------
+set expandtab
+set tabstop=4
+set softtabstop=4
+set shiftwidth=4
+set smartindent
+set autoindent
+
+" ---------- Files ----------
+set nobackup
+set nowritebackup
+set noswapfile
+set undofile
+set undodir=~/.vim/undo//
+if !isdirectory(expand('~/.vim/undo'))
+    call mkdir(expand('~/.vim/undo'), 'p')
+endif
+
+" ---------- Colorscheme ----------
+silent! colorscheme gruvbox
+
+" ---------- Leader + mappings ----------
+let mapleader = " "
+nnoremap <leader>w :w<CR>
+nnoremap <leader>q :q<CR>
+nnoremap <leader>x :x<CR>
+nnoremap <leader>h :nohlsearch<CR>
+nnoremap <leader>n :NERDTreeToggle<CR>
+nnoremap <leader>f :Files<CR>
+nnoremap <leader>b :Buffers<CR>
+nnoremap <leader>g :Rg<CR>
+nnoremap <leader>l :Lines<CR>
+nnoremap <C-h> <C-w>h
+nnoremap <C-j> <C-w>j
+nnoremap <C-k> <C-w>k
+nnoremap <C-l> <C-w>l
+
+" ---------- Plugin config ----------
+let g:lightline = { 'colorscheme': 'gruvbox' }
+let g:NERDTreeShowHidden = 1
+let g:NERDTreeMinimalUI  = 1
+let g:gitgutter_sign_column_always = 1

--- a/docker/shell-configs/zshrc
+++ b/docker/shell-configs/zshrc
@@ -1,0 +1,89 @@
+# ~/.zshrc -- Oh My Zsh + Starship
+export ZSH="$HOME/.oh-my-zsh"
+
+# Starship handles the prompt; use an empty OMZ theme.
+ZSH_THEME=""
+
+# Behavior
+CASE_SENSITIVE="false"
+HYPHEN_INSENSITIVE="true"
+DISABLE_AUTO_UPDATE="true"
+DISABLE_MAGIC_FUNCTIONS="true"
+COMPLETION_WAITING_DOTS="true"
+HIST_STAMPS="yyyy-mm-dd"
+
+plugins=(
+    git
+    docker
+    docker-compose
+    pip
+    python
+    npm
+    sudo
+    command-not-found
+    colored-man-pages
+    extract
+    zsh-autosuggestions
+    zsh-syntax-highlighting
+    zsh-completions
+)
+
+source $ZSH/oh-my-zsh.sh
+autoload -U compinit && compinit
+
+# ---------- History ----------
+HISTFILE=~/.zsh_history
+HISTSIZE=100000
+SAVEHIST=200000
+setopt APPEND_HISTORY
+setopt SHARE_HISTORY
+setopt INC_APPEND_HISTORY
+setopt HIST_IGNORE_DUPS
+setopt HIST_IGNORE_ALL_DUPS
+setopt HIST_IGNORE_SPACE
+setopt HIST_REDUCE_BLANKS
+setopt HIST_VERIFY
+setopt EXTENDED_HISTORY
+
+# ---------- Options ----------
+setopt AUTO_CD
+setopt AUTO_PUSHD
+setopt PUSHD_IGNORE_DUPS
+setopt CORRECT
+setopt INTERACTIVE_COMMENTS
+
+# ---------- Environment ----------
+export EDITOR=vim
+export PAGER=less
+export LESS='-R -i -M -w -z-4'
+export CLICOLOR=1
+
+# ---------- Aliases ----------
+alias ll='ls -alhF --color=auto'
+alias la='ls -A --color=auto'
+alias l='ls -CF --color=auto'
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+alias grep='grep --color=auto'
+alias gs='git status -sb'
+alias gd='git diff'
+alias gdc='git diff --cached'
+alias gco='git checkout'
+alias gcm='git commit -m'
+alias gp='git push'
+alias gl='git pull'
+alias glog='git log --oneline --graph --decorate --all'
+alias gb='git branch'
+alias ga='git add'
+alias dc='docker compose'
+
+# ---------- fzf ----------
+[ -f /usr/share/doc/fzf/examples/key-bindings.zsh ] && source /usr/share/doc/fzf/examples/key-bindings.zsh
+[ -f /usr/share/doc/fzf/examples/completion.zsh ] && source /usr/share/doc/fzf/examples/completion.zsh
+
+# ---------- Prompt ----------
+command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"
+
+# ---------- Local overrides ----------
+[ -f ~/.zshrc.local ] && source ~/.zshrc.local

--- a/src/ai_shell/cli/__main__.py
+++ b/src/ai_shell/cli/__main__.py
@@ -9,7 +9,7 @@ from ai_shell import __version__
 from ai_shell.cli import CONTEXT_SETTINGS
 from ai_shell.cli.commands.llm import llm_group
 from ai_shell.cli.commands.manage import manage_group
-from ai_shell.cli.commands.tools import aider, bash, claude, codex, init, opencode
+from ai_shell.cli.commands.tools import aider, claude, codex, init, opencode, shell
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -44,7 +44,7 @@ cli.add_command(claude)
 cli.add_command(codex)
 cli.add_command(opencode)
 cli.add_command(aider)
-cli.add_command(bash)
+cli.add_command(shell)
 cli.add_command(init)
 
 # Command groups

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -1,4 +1,4 @@
-"""AI tool subcommands: claude, codex, opencode, aider, bash."""
+"""AI tool subcommands: claude, codex, opencode, aider, shell."""
 
 from __future__ import annotations
 
@@ -1208,13 +1208,39 @@ def aider(ctx, safe, extra_args):
     manager.exec_interactive(name, cmd, extra_env=exec_env)
 
 
+SUPPORTED_SHELLS: dict[str, str] = {
+    "bash": "/bin/bash",
+    "zsh": "/usr/bin/zsh",
+    "fish": "/usr/bin/fish",
+}
+
+
 @click.command(context_settings=CONTEXT_SETTINGS)
+@click.argument(
+    "shell_name",
+    required=False,
+    type=click.Choice(list(SUPPORTED_SHELLS.keys()), case_sensitive=False),
+)
 @click.pass_context
-def bash(ctx):
-    """Open a bash shell in the dev container."""
+def shell(ctx, shell_name):
+    """Open an interactive shell in the dev container.
+
+    SHELL_NAME is one of bash, zsh, fish.  If omitted, an interactive
+    prompt asks which shell to launch.  All three shells come pre-configured
+    with modern defaults (Starship prompt, useful aliases, history tuning)
+    plus Oh My Zsh for zsh and Fisher for fish.
+    """
     manager, name, exec_env, _config = _get_manager(ctx)
-    console.print(f"[bold]Opening bash in {name}...[/bold]")
-    manager.exec_interactive(name, ["/bin/bash"], extra_env=exec_env)
+    if not shell_name:
+        shell_name = click.prompt(
+            "Choose shell",
+            type=click.Choice(list(SUPPORTED_SHELLS.keys()), case_sensitive=False),
+            default="bash",
+        )
+    shell_name = shell_name.lower()
+    shell_path = SUPPORTED_SHELLS[shell_name]
+    console.print(f"[bold]Opening {shell_name} in {name}...[/bold]")
+    manager.exec_interactive(name, [shell_path], extra_env=exec_env)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -360,18 +360,63 @@ class TestToolCommands:
 
         mock_check_bedrock.assert_called_once()
 
-    def test_bash_command(self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock):
+    def test_shell_bash(self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock):
         mock_build_env.return_value = dict(TEST_EXEC_ENV)
         mock_manager = MagicMock()
         mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
         mock_manager.exec_interactive.side_effect = SystemExit(0)
         mock_manager_cls.return_value = mock_manager
 
-        self.runner.invoke(cli, ["bash"])
+        self.runner.invoke(cli, ["shell", "bash"])
 
         cmd = mock_manager.exec_interactive.call_args[0][1]
         assert cmd == ["/bin/bash"]
         assert mock_manager.exec_interactive.call_args[1]["extra_env"] == TEST_EXEC_ENV
+
+    def test_shell_zsh(self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock):
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        self.runner.invoke(cli, ["shell", "zsh"])
+
+        cmd = mock_manager.exec_interactive.call_args[0][1]
+        assert cmd == ["/usr/bin/zsh"]
+
+    def test_shell_fish(self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock):
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        self.runner.invoke(cli, ["shell", "fish"])
+
+        cmd = mock_manager.exec_interactive.call_args[0][1]
+        assert cmd == ["/usr/bin/fish"]
+
+    def test_shell_prompts_when_no_arg(
+        self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        # Simulate user selecting "zsh" at the prompt.
+        self.runner.invoke(cli, ["shell"], input="zsh\n")
+
+        cmd = mock_manager.exec_interactive.call_args[0][1]
+        assert cmd == ["/usr/bin/zsh"]
+
+    def test_shell_rejects_invalid(
+        self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        result = self.runner.invoke(cli, ["shell", "csh"])
+        assert result.exit_code != 0
 
     def test_aider_passes_model_and_env(
         self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock


### PR DESCRIPTION
Replaces the single-shell bash subcommand with a shell subcommand that
accepts bash, zsh, or fish and prompts interactively when no shell is
given.  The container now ships with Starship as a cross-shell prompt,
Oh My Zsh (with zsh-autosuggestions / zsh-syntax-highlighting / zsh-
completions), Fisher (with autopair.fish and fzf.fish), gpakosz/.tmux
(Oh My Tmux), and vim-plug pre-installed with vim-sensible, fugitive,
commentary, surround, gitgutter, lightline, nerdtree, fzf.vim, and
gruvbox.  Bash, vim, and tmux configs are externalised into
docker/shell-configs/ instead of being built via repeated heredocs.