### PR TITLE
fix(container): auto-detect stale Docker images and fix shell configs

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -359,33 +359,59 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' &&
-      github.ref == 'refs/heads/main' &&
-      needs.release.outputs.released == 'true'
+      github.ref == 'refs/heads/main'
     permissions:
       contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect Docker file changes
+        id: changes
+        run: |
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q '^docker/'; then
+            echo "docker_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "docker_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine image tags
+        id: tags
+        if: needs.release.outputs.released == 'true' || steps.changes.outputs.docker_changed == 'true'
+        run: |
+          TAGS="svange/augint-shell:latest"
+          if [ "${{ needs.release.outputs.released }}" = "true" ]; then
+            TAGS="${TAGS}
+          svange/augint-shell:${{ needs.release.outputs.version }}"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
+        if: needs.release.outputs.released == 'true' || steps.changes.outputs.docker_changed == 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Docker Hub
+        if: needs.release.outputs.released == 'true' || steps.changes.outputs.docker_changed == 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        if: needs.release.outputs.released == 'true' || steps.changes.outputs.docker_changed == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: docker/
           file: docker/Dockerfile
           push: true
-          tags: |
-            svange/augint-shell:${{ needs.release.outputs.version }}
-            svange/augint-shell:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -153,13 +153,20 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
     git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
         /root/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && \
     git clone --depth=1 https://github.com/zsh-users/zsh-completions \
-        /root/.oh-my-zsh/custom/plugins/zsh-completions
+        /root/.oh-my-zsh/custom/plugins/zsh-completions && \
+    git clone --depth=1 https://github.com/zsh-users/zsh-history-substring-search \
+        /root/.oh-my-zsh/custom/plugins/zsh-history-substring-search
 
-# Install Fisher (fish plugin manager) + popular plugins
+# Install Fisher (fish plugin manager) + plugins
 RUN mkdir -p /root/.config/fish/functions /root/.config/fish/completions /root/.config/fish/conf.d && \
     curl -sSL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish \
-        -o /root/.config/fish/functions/fisher.fish && \
-    fish -c "fisher install jorgebucaran/fisher jorgebucaran/autopair.fish PatrickF1/fzf.fish" || true
+        -o /root/.config/fish/functions/fisher.fish
+RUN fish -c "source /root/.config/fish/functions/fisher.fish && fisher install jorgebucaran/fisher"
+RUN fish -c "fisher install jorgebucaran/autopair.fish"
+RUN fish -c "fisher install PatrickF1/fzf.fish"
+RUN fish -c "fisher install meaningful-ooo/sponge"
+RUN fish -c "fisher install jorgebucaran/replay.fish"
+RUN fish -c "fisher install jethrokuan/z"
 
 # Install Oh My Tmux (gpakosz/.tmux)
 RUN git clone --depth=1 https://github.com/gpakosz/.tmux.git /root/.tmux && \
@@ -179,6 +186,9 @@ COPY shell-configs/tmux.conf.local /root/.tmux.conf.local
 
 # Pre-install vim plugins headlessly so first launch is instant
 RUN vim -es -u /root/.vimrc -i NONE -c "PlugInstall --sync" -c "qa" || true
+
+# Pre-generate zsh completion dump so first launch is fast
+RUN zsh -c "autoload -Uz compinit && compinit" || true
 
 # Install additional useful development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/shell-configs/bashrc
+++ b/docker/shell-configs/bashrc
@@ -2,6 +2,7 @@
 case $- in *i*) ;; *) return;; esac
 
 # ---------- History ----------
+HISTFILE=~/.bash_history
 HISTCONTROL=ignoreboth:erasedups
 HISTSIZE=100000
 HISTFILESIZE=200000

--- a/docker/shell-configs/fish-config.fish
+++ b/docker/shell-configs/fish-config.fish
@@ -10,33 +10,38 @@ if status is-interactive
     # ---------- Greeting ----------
     set -g fish_greeting ""
 
-    # ---------- Aliases ----------
-    alias ll 'ls -alhF --color=auto'
-    alias la 'ls -A --color=auto'
-    alias l  'ls -CF --color=auto'
-    alias grep 'grep --color=auto'
+    # ---------- History ----------
+    set -g fish_history default
+    set -g fish_history_max 100000
+
+    # ---------- Abbreviations ----------
+    # Fish handles --color=auto natively via built-in wrapper functions.
+    # Abbreviations expand in-place, giving readable history and real commands.
+
+    # Listing
+    abbr -a ll 'ls -alhF'
+    abbr -a la 'ls -A'
+    abbr -a l  'ls -CF'
 
     # Navigation
-    alias ..  'cd ..'
-    alias ... 'cd ../..'
-    alias .... 'cd ../../..'
+    abbr -a .. 'cd ..'
+    abbr -a ... 'cd ../..'
+    abbr -a .... 'cd ../../..'
 
     # Git
-    alias gs 'git status -sb'
-    alias gd 'git diff'
-    alias gdc 'git diff --cached'
-    alias gco 'git checkout'
-    alias gcm 'git commit -m'
-    alias gp 'git push'
-    alias gl 'git pull'
-    alias glog 'git log --oneline --graph --decorate --all'
-    alias gb 'git branch'
-    alias ga 'git add'
+    abbr -a gs 'git status -sb'
+    abbr -a gd 'git diff'
+    abbr -a gdc 'git diff --cached'
+    abbr -a gco 'git checkout'
+    abbr -a gcm 'git commit -m'
+    abbr -a gp 'git push'
+    abbr -a gl 'git pull'
+    abbr -a glog 'git log --oneline --graph --decorate --all'
+    abbr -a gb 'git branch'
+    abbr -a ga 'git add'
 
     # Docker
-    alias dc 'docker compose'
-
-    # ---------- fzf.fish key-bindings auto-register from the plugin ----------
+    abbr -a dc 'docker compose'
 
     # ---------- Prompt ----------
     if type -q starship

--- a/docker/shell-configs/starship.toml
+++ b/docker/shell-configs/starship.toml
@@ -6,7 +6,7 @@ format = """
 $character """
 
 add_newline = false
-command_timeout = 1000
+command_timeout = 500
 
 [character]
 success_symbol = "[>](bold green)"
@@ -17,10 +17,10 @@ vicmd_symbol = "[<](bold yellow)"
 style_user = "bold cyan"
 style_root = "bold red"
 format = "[$user]($style)"
-show_always = true
+show_always = false
 
 [hostname]
-ssh_only = false
+ssh_only = true
 format = "@[$hostname](bold purple) "
 disabled = false
 

--- a/docker/shell-configs/zshrc
+++ b/docker/shell-configs/zshrc
@@ -9,6 +9,7 @@ CASE_SENSITIVE="false"
 HYPHEN_INSENSITIVE="true"
 DISABLE_AUTO_UPDATE="true"
 DISABLE_MAGIC_FUNCTIONS="true"
+DISABLE_COMPFIX="true"
 COMPLETION_WAITING_DOTS="true"
 HIST_STAMPS="yyyy-mm-dd"
 
@@ -20,16 +21,18 @@ plugins=(
     python
     npm
     sudo
-    command-not-found
     colored-man-pages
     extract
     zsh-autosuggestions
     zsh-syntax-highlighting
     zsh-completions
+    zsh-history-substring-search
 )
 
+# Add zsh-completions to fpath before compinit (run by OMZ source)
+fpath+=(${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-completions/src)
+
 source $ZSH/oh-my-zsh.sh
-autoload -U compinit && compinit
 
 # ---------- History ----------
 HISTFILE=~/.zsh_history
@@ -37,12 +40,14 @@ HISTSIZE=100000
 SAVEHIST=200000
 setopt APPEND_HISTORY
 setopt SHARE_HISTORY
-setopt INC_APPEND_HISTORY
 setopt HIST_IGNORE_DUPS
 setopt HIST_IGNORE_ALL_DUPS
 setopt HIST_IGNORE_SPACE
 setopt HIST_REDUCE_BLANKS
 setopt HIST_VERIFY
+setopt HIST_EXPIRE_DUPS_FIRST
+setopt HIST_FIND_NO_DUPS
+setopt HIST_SAVE_NO_DUPS
 setopt EXTENDED_HISTORY
 
 # ---------- Options ----------
@@ -81,6 +86,12 @@ alias dc='docker compose'
 # ---------- fzf ----------
 [ -f /usr/share/doc/fzf/examples/key-bindings.zsh ] && source /usr/share/doc/fzf/examples/key-bindings.zsh
 [ -f /usr/share/doc/fzf/examples/completion.zsh ] && source /usr/share/doc/fzf/examples/completion.zsh
+
+# ---------- History substring search (up/down arrow) ----------
+bindkey '^[[A' history-substring-search-up
+bindkey '^[[B' history-substring-search-down
+bindkey -M vicmd 'k' history-substring-search-up
+bindkey -M vicmd 'j' history-substring-search-down
 
 # ---------- Prompt ----------
 command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"

--- a/src/ai_shell/container.py
+++ b/src/ai_shell/container.py
@@ -142,16 +142,22 @@ class ContainerManager:
 
         If the container exists but is stopped, it is started.
         If it doesn't exist, it is created with the full configuration.
+        If using the ``latest`` tag and a newer image is available, the
+        existing container is replaced automatically.
 
         Returns the container name.
         """
         name, container = self.resolve_dev_container()
 
         if container is not None:
-            if container.status != "running":
-                logger.info("Starting existing container: %s", name)
-                container.start()
-            return name
+            if self._recreate_if_image_stale(container, name):
+                # Container was removed; fall through to create a new one.
+                container = None
+            else:
+                if container.status != "running":
+                    logger.info("Starting existing container: %s", name)
+                    container.start()
+                return name
 
         logger.info("Creating dev container: %s", name)
         self._pull_image_if_needed(self.config.full_image)
@@ -302,6 +308,39 @@ class ContainerManager:
             label,
             had,
             want,
+        )
+        container.remove(force=True)
+        return True
+
+    def _recreate_if_image_stale(self, container: Container, name: str) -> bool:
+        """Pull the latest image and recreate the container if it is outdated.
+
+        Only acts when the configured tag is ``latest``.  For pinned
+        version tags the image is immutable so staleness doesn't apply.
+
+        Returns True if the container was removed (caller must recreate).
+        """
+        tag = self.config.image_tag
+        if tag != "latest":
+            return False
+
+        image_ref = self.config.full_image
+        try:
+            pulled = self.client.images.pull(*image_ref.rsplit(":", 1))
+        except APIError:
+            logger.debug("Could not pull %s — skipping staleness check", image_ref)
+            return False
+
+        container_image_id = container.image.id
+        pulled_image_id = pulled.id
+
+        if container_image_id == pulled_image_id:
+            return False
+
+        logger.warning(
+            "Dev container %s uses an outdated image — recreating with %s",
+            name,
+            image_ref,
         )
         container.remove(force=True)
         return True

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from docker.errors import APIError
 
 from ai_shell.config import AiShellConfig
 from ai_shell.defaults import (
@@ -161,6 +162,7 @@ class TestEnsureDevContainer:
         stopped_container = MagicMock()
         stopped_container.status = "exited"
         mock_container_manager._get_container = MagicMock(return_value=stopped_container)
+        mock_container_manager._recreate_if_image_stale = MagicMock(return_value=False)
 
         name = mock_container_manager.ensure_dev_container()
 
@@ -172,6 +174,7 @@ class TestEnsureDevContainer:
         running_container = MagicMock()
         running_container.status = "running"
         mock_container_manager._get_container = MagicMock(return_value=running_container)
+        mock_container_manager._recreate_if_image_stale = MagicMock(return_value=False)
 
         name = mock_container_manager.ensure_dev_container()
 
@@ -192,6 +195,7 @@ class TestEnsureDevContainer:
             return None
 
         mock_container_manager._get_container = MagicMock(side_effect=get_container)
+        mock_container_manager._recreate_if_image_stale = MagicMock(return_value=False)
 
         name = mock_container_manager.ensure_dev_container()
 
@@ -212,6 +216,44 @@ class TestEnsureDevContainer:
         assert name.endswith("-dev")
         assert name != "augint-shell-test-project-dev"
         legacy_container.start.assert_not_called()
+
+
+class TestRecreateIfImageStale:
+    def test_skips_for_pinned_tag(self, mock_container_manager):
+        mock_container_manager.config.image_tag = "0.84.0"
+        container = MagicMock()
+        assert mock_container_manager._recreate_if_image_stale(container, "test") is False
+        container.remove.assert_not_called()
+
+    def test_skips_when_image_matches(self, mock_container_manager):
+        mock_container_manager.config.image_tag = "latest"
+        pulled_image = MagicMock()
+        pulled_image.id = "sha256:abc123"
+        mock_container_manager.client.images.pull.return_value = pulled_image
+        container = MagicMock()
+        container.image.id = "sha256:abc123"
+
+        assert mock_container_manager._recreate_if_image_stale(container, "test") is False
+        container.remove.assert_not_called()
+
+    def test_recreates_when_image_outdated(self, mock_container_manager):
+        mock_container_manager.config.image_tag = "latest"
+        pulled_image = MagicMock()
+        pulled_image.id = "sha256:new456"
+        mock_container_manager.client.images.pull.return_value = pulled_image
+        container = MagicMock()
+        container.image.id = "sha256:old123"
+
+        assert mock_container_manager._recreate_if_image_stale(container, "test") is True
+        container.remove.assert_called_once_with(force=True)
+
+    def test_skips_on_pull_failure(self, mock_container_manager):
+        mock_container_manager.config.image_tag = "latest"
+        mock_container_manager.client.images.pull.side_effect = APIError("network error")
+        container = MagicMock()
+
+        assert mock_container_manager._recreate_if_image_stale(container, "test") is False
+        container.remove.assert_not_called()
 
 
 class TestExecInteractive:


### PR DESCRIPTION
## Summary
- **Image staleness detection**: Dev containers now auto-pull latest image on launch and recreate when outdated, following the existing GPU recreation pattern
- **Docker CI trigger**: Pipeline publishes Docker images to DockerHub when `docker/**` files change on main, not only on semantic releases
- **Shell config fixes**: Remove duplicate zsh compinit, fix SHARE_HISTORY/INC_APPEND_HISTORY conflict, switch fish to idiomatic abbreviations, reduce starship prompt noise, split Fisher installs for debuggability, add new plugins (sponge, replay.fish, z, zsh-history-substring-search)

## Test plan
- [x] 474 unit tests passing
- [x] Pre-commit hooks passing (ruff, mypy, yaml, etc.)
- [x] 4 new tests for `_recreate_if_image_stale` (pinned skip, matching image, outdated recreate, pull failure fallback)
- [ ] Rebuild Docker image and verify `ai-shell shell zsh` and `ai-shell shell fish` launch correctly
- [ ] Verify pipeline triggers Docker publish on `docker/` changes without a semantic release