### PR TITLE
fix(docker): remove self-referential Fisher install that breaks Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -158,10 +158,12 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
         /root/.oh-my-zsh/custom/plugins/zsh-history-substring-search
 
 # Install Fisher (fish plugin manager) + plugins
+# Bootstrap fisher by downloading it, then install plugins individually.
+# Do NOT run "fisher install jorgebucaran/fisher" -- it conflicts with the
+# manually downloaded fisher.fish file.
 RUN mkdir -p /root/.config/fish/functions /root/.config/fish/completions /root/.config/fish/conf.d && \
     curl -sSL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish \
         -o /root/.config/fish/functions/fisher.fish
-RUN fish -c "source /root/.config/fish/functions/fisher.fish && fisher install jorgebucaran/fisher"
 RUN fish -c "fisher install jorgebucaran/autopair.fish"
 RUN fish -c "fisher install PatrickF1/fzf.fish"
 RUN fish -c "fisher install meaningful-ooo/sponge"


### PR DESCRIPTION
## Summary
- Fisher bootstrap downloads `fisher.fish` manually, then `fisher install jorgebucaran/fisher` tries to overwrite that same file and fails with "Cannot install: please remove or move conflicting files first"
- Fix: skip the self-install step -- the manual download already provides fisher

## Context
The Docker publish job in PR #83's merge pipeline failed because of this. The Python package (0.84.1) published fine, but the Docker image was not updated.

## Test plan
- [ ] Pipeline `publish-docker` job succeeds after merge
- [ ] Docker image on DockerHub includes fish with Fisher plugins