### PR TITLE
fix(shell): use # as prompt character since $ is reserved by starship

### DIFF
--- a/docker/shell-configs/starship.toml
+++ b/docker/shell-configs/starship.toml
@@ -9,7 +9,7 @@ add_newline = true
 command_timeout = 500
 
 [character]
-success_symbol = '[$](bold green)'
+success_symbol = '[#](bold green)'
 error_symbol = '[!](bold red)'
 vicmd_symbol = '[<](bold yellow)'
 


### PR DESCRIPTION
## Summary

- Starship's format parser treats `$` as a variable reference with no escape mechanism, causing a parse error on every prompt render
- Replace with `#`, the traditional Unix root prompt character (container always runs as root)

## Test plan

- [x] `uv run pre-commit run --all-files` -- all hooks pass
- [x] Shell tests pass
- [ ] After Docker rebuild: prompt shows `#` in green (success) or `!` in red (error) with no warnings