### PR TITLE
feat(llm): add ANSI escape stripping for ollama pull output

### DIFF
--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -14,6 +14,7 @@ Stack flags (applied to up/down/clean/setup):
 ``llm up`` with no flags starts only the base Ollama container.
 """
 
+import re
 import socket
 import time
 from http.client import HTTPException, HTTPSConnection
@@ -44,6 +45,7 @@ from ai_shell.gpu import get_vram_info, get_vram_processes
 
 console = Console(stderr=True)
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 _LOW_MEMORY_THRESHOLD_GIB = 30  # 27B+ models need ~30 GiB
 _OLLAMA_REGISTRY_HOST = "registry.ollama.ai"
 _MANIFEST_PROBE_TIMEOUT = 5.0
@@ -131,6 +133,38 @@ def _validate_models_or_abort(*model_refs: str) -> None:
         "entry (or [bold]extra_models[/bold]) in your ai-shell config to a valid tag and retry."
     )
     raise click.Abort()
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences and collapse carriage-return overwrites.
+
+    ``ollama pull`` emits VT100 codes (bold, erase-line) and ``\\r``-based
+    progress bars that render as garbage in non-VT100 terminals (e.g.
+    PowerShell). This function strips all of that and returns only the
+    final state of each progress line.
+    """
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    # Progress bars use \r to overwrite the line; keep only the last segment.
+    lines: list[str] = []
+    for line in text.split("\n"):
+        segments = line.split("\r")
+        final = segments[-1].strip()
+        if final:
+            lines.append(final)
+    return "\n".join(lines)
+
+
+def _pull_models(manager: ContainerManager, models: tuple[str, ...] | list[str]) -> None:
+    """Pull one or more Ollama models with a spinner and clean output."""
+    for model in models:
+        with console.status(f"[bold]Pulling {model}...[/bold]", spinner="dots"):
+            output = manager.exec_in_ollama(["ollama", "pull", model])
+        clean = _strip_ansi(output)
+        if "success" in clean.lower():
+            console.print(f"  [green]Pulled {model}[/green]")
+        else:
+            console.print(f"  [yellow]{model}:[/yellow]")
+            console.print(clean)
 
 
 def _lan_ip() -> str | None:
@@ -526,10 +560,7 @@ def llm_pull(ctx):
     models = config.models_to_pull
     _validate_models_or_abort(*models)
 
-    for model in models:
-        console.print(f"[bold]Pulling {model}...[/bold]")
-        output = manager.exec_in_ollama(["ollama", "pull", model])
-        console.print(output)
+    _pull_models(manager, models)
 
     console.print("\n[bold]Available models:[/bold]")
     output = manager.exec_in_ollama(["ollama", "list"])
@@ -635,10 +666,7 @@ def llm_setup(
         console.print("[bold red]Ollama failed to start after 20s[/bold red]")
         raise click.Abort()
 
-    for model in models:
-        console.print(f"\n[bold]Pulling {model}...[/bold]")
-        output = manager.exec_in_ollama(["ollama", "pull", model])
-        console.print(output)
+    _pull_models(manager, models)
 
     console.print("\n[bold green]============================================[/bold green]")
     console.print("[bold green] Setup complete![/bold green]")

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ dev = [
 
 [[package]]
 name = "augint-tools"
-version = "5.0.0"
+version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -99,9 +99,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/4e/ec04090a58aefbec0ab185462eaead4b8512f9814e425696ef10bbb5d815/augint_tools-5.0.0.tar.gz", hash = "sha256:02a498236f3ea1bc0f32bd0f1a4d70e20200842a183b101a2d2b5450e17e4f82", size = 95171, upload-time = "2026-04-17T00:14:36.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/2b/f91b0937ecbe610b9e9ef51f29c221b66d85ce6a9524143c9bbbb624283c/augint_tools-5.1.0.tar.gz", hash = "sha256:8825004c64bf2f78783bb159f55a8c9b2dc2cdcb8836679b8dd06f4a75964313", size = 96388, upload-time = "2026-04-17T01:57:35.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/06/e59d64ee63aaa54b9224f7aa1c1d39c7cf90f7f708b07ae91fc7f1b32e77/augint_tools-5.0.0-py3-none-any.whl", hash = "sha256:d292022e68251750d4b833eef396c217473ddb4c48770ab5c01ae3616576dcc2", size = 133039, upload-time = "2026-04-17T00:14:34.641Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/6b566eee05e133f4c9fff18b1436ec91c460a81e34f06c031f6c210e0374/augint_tools-5.1.0-py3-none-any.whl", hash = "sha256:614ec485623ffdc70026632dbcd70a0fc4608d037c965d036985723b43956478", size = 134289, upload-time = "2026-04-17T01:57:34.3Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Strip VT100 escape sequences and carriage-return progress bars from `ollama pull` output for clean display in non-VT100 terminals (e.g. PowerShell)
- Refactor model pulling into a shared `_pull_models()` helper used by both `llm pull` and `llm setup`

## Test plan
- [ ] Run `ai-shell llm pull` and verify clean output without ANSI garbage
- [ ] Run `ai-shell llm setup` and verify same clean output
- [ ] Verify pre-commit passes