### PR TITLE
feat(llm): add model catalog and llm models browsing command

### DIFF
--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -567,6 +567,126 @@ def llm_pull(ctx):
     console.print(output)
 
 
+@llm_group.command("models")
+@click.option("--pulled", is_flag=True, help="Only show models that are downloaded in Ollama.")
+@click.option(
+    "--role",
+    type=click.Choice(["chat", "coding"], case_sensitive=False),
+    default=None,
+    help="Filter by model role.",
+)
+@click.option("--uncensored", is_flag=True, help="Only show uncensored / abliterated models.")
+@click.pass_context
+def llm_models(ctx, pulled: bool, role: str | None, uncensored: bool):
+    """Browse available LLM models with metadata.
+
+    Shows a table of curated models cross-referenced against the active
+    config and Ollama state. Each row shows the model tag, role, parameter
+    count, disk size, uncensored marker, status, and description.
+
+    \b
+    Status meanings:
+      config     in one of the 4 config slots or extra_models
+      pulled     downloaded in Ollama but not in active config
+      available  in catalog but not yet pulled
+      untracked  in Ollama but not in the curated catalog
+    """
+    from ai_shell.models import MODEL_CATALOG, ModelInfo, classify_status
+
+    manager = _get_manager(ctx)
+    config = manager.config
+
+    # Gather config tags (all 4 slots + extra_models)
+    config_tags: set[str] = set(config.models_to_pull)
+
+    # Gather pulled tags from Ollama (if running)
+    pulled_tags: set[str] = set()
+    ollama_running = manager.container_status(OLLAMA_CONTAINER) == "running"
+    if ollama_running:
+        output = manager.exec_in_ollama(["ollama", "list"])
+        for line in output.splitlines()[1:]:  # skip header
+            parts = line.split()
+            if parts:
+                # ollama list shows "name:tag" in first column
+                pulled_tags.add(parts[0])
+
+    # Build row list: catalog entries first, then untracked Ollama models
+    rows: list[tuple[ModelInfo | None, str, str]] = []
+
+    for info in MODEL_CATALOG:
+        status = classify_status(info.tag, config_tags, pulled_tags)
+        rows.append((info, info.tag, status))
+
+    # Untracked models (in Ollama but not in catalog)
+    catalog_tags = {m.tag for m in MODEL_CATALOG}
+    for tag in sorted(pulled_tags - catalog_tags - config_tags):
+        rows.append((None, tag, "untracked"))
+    # Config tags that are pulled but not in catalog
+    for tag in sorted(config_tags & pulled_tags - catalog_tags):
+        rows.append((None, tag, "config"))
+
+    # Apply filters
+    if pulled:
+        rows = [(i, t, s) for i, t, s in rows if t in pulled_tags]
+    if role:
+        rows = [(i, t, s) for i, t, s in rows if i is not None and i.role == role.lower()]
+    if uncensored:
+        rows = [(i, t, s) for i, t, s in rows if i is not None and i.uncensored]
+
+    if not rows:
+        console.print("[dim]No models match the given filters.[/dim]")
+        return
+
+    _STATUS_STYLE = {
+        "config": "bold green",
+        "pulled": "yellow",
+        "available": "dim",
+        "untracked": "dim italic",
+    }
+
+    console.print("[bold]LLM Model Catalog[/bold]\n")
+
+    current_role: str | None = None
+    for info, tag, status in rows:  # type: ignore[assignment]
+        style = _STATUS_STYLE.get(status, "")
+
+        if info is not None:
+            # Group header when role changes
+            if info.role != current_role:
+                if current_role is not None:
+                    console.print()
+                current_role = info.role
+                console.print(f"[bold underline]{info.role.upper()} models[/bold underline]")
+
+            uncensored_mark = " [bold red](U)[/bold red]" if info.uncensored else ""
+            status_text = f"[{style}]{status}[/{style}]"
+            if status == "available":
+                console.print(f"  [dim cyan]{tag}[/dim cyan]{uncensored_mark}  {status_text}")
+                console.print(
+                    f"    [dim]{info.params}  {info.size_gb:.0f} GB  {info.description}[/dim]"
+                )
+            else:
+                console.print(f"  [cyan]{tag}[/cyan]{uncensored_mark}  {status_text}")
+                console.print(f"    {info.params}  {info.size_gb:.0f} GB  {info.description}")
+            if info.caveats and status == "config":
+                console.print(f"    [dim yellow]caveat: {info.caveats}[/dim yellow]")
+        else:
+            # Untracked or config-but-not-cataloged model
+            if current_role != "_untracked":
+                if current_role is not None:
+                    console.print()
+                current_role = "_untracked"
+                console.print("[bold underline]OTHER models (not in catalog)[/bold underline]")
+            status_text = f"[{style}]{status}[/{style}]"
+            console.print(f"  [dim cyan]{tag}[/dim cyan]  {status_text}")
+
+    if not ollama_running:
+        console.print(
+            "\n[yellow]Ollama is not running — pulled status may be incomplete. "
+            "Run [bold]ai-shell llm up[/bold] first.[/yellow]"
+        )
+
+
 @llm_group.command("unload")
 @click.argument("model", required=False)
 @click.pass_context

--- a/src/ai_shell/models.py
+++ b/src/ai_shell/models.py
@@ -1,0 +1,178 @@
+"""Curated model catalog for ai-shell.
+
+Each entry represents an Ollama model tag that has been validated on
+RTX 4090-class hardware. The catalog ships with ai-shell and is the
+single source of truth for model metadata (role, parameter count,
+censored/uncensored, disk footprint, known caveats).
+
+The ``llm models`` CLI command cross-references this catalog against
+the active config slots and the models actually pulled into Ollama.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Metadata for a single Ollama model tag."""
+
+    tag: str
+    role: str  # "chat" | "coding"
+    params: str  # e.g. "3B", "8B", "14B", "27B", "30B"
+    size_gb: float  # approximate disk footprint in GiB
+    uncensored: bool  # True = abliterated / uncensored variant
+    description: str  # one-line purpose
+    caveats: str = ""  # known issues or limitations
+
+
+# ---------------------------------------------------------------------------
+# Catalog — ordered by role then descending parameter count
+# ---------------------------------------------------------------------------
+MODEL_CATALOG: tuple[ModelInfo, ...] = (
+    # ── Chat models ───────────────────────────────────────────────────────
+    ModelInfo(
+        tag="qwen3.5:27b",
+        role="chat",
+        params="27B",
+        size_gb=17.0,
+        uncensored=False,
+        description="Primary chat — best quality, heavy on VRAM",
+        caveats="Ollama tool-call bug (ollama #14493)",
+    ),
+    ModelInfo(
+        tag="huihui_ai/qwen3.5-abliterated:27b",
+        role="chat",
+        params="27B",
+        size_gb=17.0,
+        uncensored=True,
+        description="Uncensored chat — abliterated Qwen3.5 27B",
+        caveats="Ollama tool-call bug (ollama #14493)",
+    ),
+    ModelInfo(
+        tag="qwen3.5:14b-instruct",
+        role="chat",
+        params="14B",
+        size_gb=9.0,
+        uncensored=False,
+        description="Mid-range chat — 4090 sweet spot, fast + capable",
+    ),
+    ModelInfo(
+        tag="huihui_ai/qwen3.5-abliterated:14b",
+        role="chat",
+        params="14B",
+        size_gb=9.0,
+        uncensored=True,
+        description="Mid-range uncensored chat — abliterated Qwen3.5 14B",
+    ),
+    ModelInfo(
+        tag="dolphin3:8b",
+        role="chat",
+        params="8B",
+        size_gb=5.0,
+        uncensored=True,
+        description="Fast uncensored — Dolphin fine-tune of Llama 3.1 8B",
+    ),
+    ModelInfo(
+        tag="llama3.1:8b",
+        role="chat",
+        params="8B",
+        size_gb=5.0,
+        uncensored=False,
+        description="Fast general chat — good for quick tasks",
+    ),
+    ModelInfo(
+        tag="gemma3:12b",
+        role="chat",
+        params="12B",
+        size_gb=8.0,
+        uncensored=False,
+        description="Google Gemma 3 12B — solid mid-range alternative",
+    ),
+    ModelInfo(
+        tag="llama3.2:latest",
+        role="chat",
+        params="3B",
+        size_gb=2.0,
+        uncensored=False,
+        description="Ultra-fast 3B — limited capability, near-instant",
+    ),
+    # ── Coding models ─────────────────────────────────────────────────────
+    ModelInfo(
+        tag="qwen3-coder:30b-a3b-q4_K_M",
+        role="coding",
+        params="30B",
+        size_gb=19.0,
+        uncensored=False,
+        description="Primary coding — explicit Ollama tools badge",
+        caveats="Reliable native tool_calls below ~5 tools",
+    ),
+    ModelInfo(
+        tag="huihui_ai/qwen3-coder-abliterated:30b-a3b-instruct-q4_K_M",
+        role="coding",
+        params="30B",
+        size_gb=19.0,
+        uncensored=True,
+        description="Uncensored coding — abliterated Qwen3-Coder 30B",
+        caveats="Reliable native tool_calls below ~5 tools",
+    ),
+    ModelInfo(
+        tag="qwen2.5-coder:14b-instruct",
+        role="coding",
+        params="14B",
+        size_gb=9.0,
+        uncensored=False,
+        description="Mid-range coding — previous-gen, proven on 4090",
+    ),
+    ModelInfo(
+        tag="qwen2.5-coder:32b-q4_k_m",
+        role="coding",
+        params="32B",
+        size_gb=19.0,
+        uncensored=False,
+        description="Large Qwen2.5-Coder — previous-gen, needs full VRAM",
+    ),
+    ModelInfo(
+        tag="devstral:24b",
+        role="coding",
+        params="24B",
+        size_gb=15.0,
+        uncensored=False,
+        description="Mistral Devstral — strong agentic coding model",
+    ),
+)
+
+# Fast lookup by tag
+_CATALOG_BY_TAG: dict[str, ModelInfo] = {m.tag: m for m in MODEL_CATALOG}
+
+
+def lookup(tag: str) -> ModelInfo | None:
+    """Return catalog entry for *tag*, or ``None`` if untracked."""
+    return _CATALOG_BY_TAG.get(tag)
+
+
+def classify_status(
+    tag: str,
+    config_tags: set[str],
+    pulled_tags: set[str],
+) -> str:
+    """Classify a model's status relative to config and Ollama state.
+
+    Returns one of:
+    - ``"config"``    — in one of the 4 config slots (or extra_models)
+    - ``"pulled"``    — downloaded in Ollama but not in config
+    - ``"available"`` — in catalog but not pulled
+    - ``"untracked"`` — pulled in Ollama but not in catalog
+    """
+    in_config = tag in config_tags
+    in_ollama = tag in pulled_tags
+    in_catalog = tag in _CATALOG_BY_TAG
+
+    if in_config:
+        return "config"
+    if in_ollama and in_catalog:
+        return "pulled"
+    if in_ollama and not in_catalog:
+        return "untracked"
+    return "available"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,311 @@
+"""Tests for the model catalog and llm models command."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from ai_shell.cli.__main__ import cli
+from ai_shell.models import MODEL_CATALOG, classify_status, lookup
+
+# ---------------------------------------------------------------------------
+# Unit tests for models.py
+# ---------------------------------------------------------------------------
+
+
+class TestModelInfo:
+    def test_frozen(self):
+        info = MODEL_CATALOG[0]
+        try:
+            info.tag = "nope"  # type: ignore[misc]
+            raise AssertionError("Expected FrozenInstanceError")
+        except AttributeError:
+            pass
+
+    def test_catalog_has_entries(self):
+        assert len(MODEL_CATALOG) > 0
+
+    def test_all_entries_have_required_fields(self):
+        for info in MODEL_CATALOG:
+            assert info.tag, f"Missing tag on {info}"
+            assert info.role in ("chat", "coding"), f"Bad role on {info.tag}"
+            assert info.params, f"Missing params on {info.tag}"
+            assert info.size_gb > 0, f"Bad size on {info.tag}"
+            assert isinstance(info.uncensored, bool)
+            assert info.description, f"Missing description on {info.tag}"
+
+    def test_no_duplicate_tags(self):
+        tags = [m.tag for m in MODEL_CATALOG]
+        assert len(tags) == len(set(tags)), (
+            f"Duplicate tags: {[t for t in tags if tags.count(t) > 1]}"
+        )
+
+
+class TestLookup:
+    def test_known_model(self):
+        info = lookup("qwen3.5:27b")
+        assert info is not None
+        assert info.role == "chat"
+        assert info.params == "27B"
+
+    def test_unknown_model(self):
+        assert lookup("nonexistent:latest") is None
+
+    def test_uncensored_model(self):
+        info = lookup("huihui_ai/qwen3.5-abliterated:27b")
+        assert info is not None
+        assert info.uncensored is True
+
+
+class TestClassifyStatus:
+    def test_config_model(self):
+        config_tags = {"qwen3.5:27b"}
+        pulled_tags = {"qwen3.5:27b"}
+        assert classify_status("qwen3.5:27b", config_tags, pulled_tags) == "config"
+
+    def test_config_even_if_not_pulled(self):
+        config_tags = {"qwen3.5:27b"}
+        pulled_tags: set[str] = set()
+        assert classify_status("qwen3.5:27b", config_tags, pulled_tags) == "config"
+
+    def test_pulled_but_not_config(self):
+        config_tags: set[str] = set()
+        pulled_tags = {"qwen3.5:14b-instruct"}
+        assert classify_status("qwen3.5:14b-instruct", config_tags, pulled_tags) == "pulled"
+
+    def test_available_in_catalog_only(self):
+        config_tags: set[str] = set()
+        pulled_tags: set[str] = set()
+        assert classify_status("qwen3.5:14b-instruct", config_tags, pulled_tags) == "available"
+
+    def test_untracked_not_in_catalog(self):
+        config_tags: set[str] = set()
+        pulled_tags = {"some-random-model:latest"}
+        assert classify_status("some-random-model:latest", config_tags, pulled_tags) == "untracked"
+
+    def test_config_wins_over_pulled(self):
+        """A model in both config and pulled should show as 'config'."""
+        config_tags = {"dolphin3:8b"}
+        pulled_tags = {"dolphin3:8b"}
+        assert classify_status("dolphin3:8b", config_tags, pulled_tags) == "config"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests for `llm models`
+# ---------------------------------------------------------------------------
+
+
+def _make_manager_config() -> MagicMock:
+    config = MagicMock()
+    config.ollama_port = 11434
+    config.webui_port = 3000
+    config.kokoro_port = 8880
+    config.kokoro_voice = "af_bella"
+    config.n8n_port = 5678
+    config.comfyui_port = 8188
+    config.whisper_port = 8001
+    config.whisper_model = "Systran/faster-distil-whisper-large-v3"
+    config.voice_agent = MagicMock()
+    config.voice_agent.port = 8010
+    config.primary_chat_model = "qwen3.5:27b"
+    config.secondary_chat_model = "huihui_ai/qwen3.5-abliterated:27b"
+    config.primary_coding_model = "qwen3-coder:30b-a3b-q4_K_M"
+    config.secondary_coding_model = "huihui_ai/qwen3-coder-abliterated:30b-a3b-instruct-q4_K_M"
+    config.extra_models = []
+    config.models_to_pull = [
+        config.primary_chat_model,
+        config.secondary_chat_model,
+        config.primary_coding_model,
+        config.secondary_coding_model,
+    ]
+    config.context_size = 32768
+    return config
+
+
+_FAKE_OLLAMA_LIST = (
+    "NAME                                                          ID           SIZE     MODIFIED\n"
+    "qwen3.5:27b                                                   abc123       17 GB    2 days ago\n"
+    "huihui_ai/qwen3.5-abliterated:27b                             def456       17 GB    2 days ago\n"
+    "qwen3-coder:30b-a3b-q4_K_M                                    ghi789       19 GB    3 days ago\n"
+    "huihui_ai/qwen3-coder-abliterated:30b-a3b-instruct-q4_K_M     jkl012       19 GB    3 days ago\n"
+    "llama3.2:latest                                                mno345       2 GB     5 days ago\n"
+    "mystery-model:7b                                               pqr678       4 GB     1 day ago\n"
+)
+
+
+@patch("ai_shell.cli.commands.llm.ContainerManager")
+@patch("ai_shell.cli.commands.llm.load_config")
+class TestLlmModelsCommand:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_shows_catalog_with_config_models(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models"])
+
+        assert result.exit_code == 0
+        assert "LLM Model Catalog" in result.output
+        assert "qwen3.5:27b" in result.output
+        assert "config" in result.output
+        assert "CHAT models" in result.output
+        assert "CODING models" in result.output
+
+    def test_shows_untracked_models(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models"])
+
+        assert result.exit_code == 0
+        assert "mystery-model:7b" in result.output
+        assert "untracked" in result.output
+        assert "OTHER models" in result.output
+
+    def test_shows_pulled_status_for_non_config_catalog_model(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models"])
+
+        assert result.exit_code == 0
+        # llama3.2:latest is in Ollama + catalog but not in config
+        assert "llama3.2:latest" in result.output
+        assert "pulled" in result.output
+
+    def test_pulled_filter(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models", "--pulled"])
+
+        assert result.exit_code == 0
+        # Should NOT show models that aren't pulled (e.g. qwen3.5:14b-instruct)
+        assert "available" not in result.output
+
+    def test_role_filter_chat(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models", "--role", "chat"])
+
+        assert result.exit_code == 0
+        # Should not show coding models
+        assert "qwen3-coder" not in result.output
+        # Should show chat models
+        assert "qwen3.5:27b" in result.output
+
+    def test_role_filter_coding(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models", "--role", "coding"])
+
+        assert result.exit_code == 0
+        assert "qwen3-coder" in result.output
+        # Chat-only models filtered out
+        assert "llama3.2:latest" not in result.output
+
+    def test_uncensored_filter(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models", "--uncensored"])
+
+        assert result.exit_code == 0
+        assert "(U)" in result.output
+        # Censored-only models should be filtered out (qwen3.5:27b is censored)
+        # Note: qwen3.5 appears in uncensored variant names so check exact tag
+        assert "huihui_ai/qwen3.5-abliterated:27b" in result.output
+
+    def test_warns_when_ollama_not_running(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = None
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models"])
+
+        assert result.exit_code == 0
+        assert "Ollama is not running" in result.output
+
+    def test_no_matches_message(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        # Only non-catalog model pulled, filter by --uncensored + --role coding
+        manager.exec_in_ollama.return_value = (
+            "NAME    ID    SIZE    MODIFIED\nmystery-model:7b    abc    4 GB    1 day ago\n"
+        )
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(
+            cli, ["llm", "models", "--uncensored", "--role", "coding", "--pulled"]
+        )
+
+        assert result.exit_code == 0
+        assert "No models match" in result.output
+
+    def test_shows_caveats_for_config_models(self, mock_config, mock_manager_cls):
+        config = _make_manager_config()
+        mock_config.return_value = config
+
+        manager = MagicMock()
+        manager.config = config
+        manager.container_status.return_value = "running"
+        manager.exec_in_ollama.return_value = _FAKE_OLLAMA_LIST
+        mock_manager_cls.return_value = manager
+
+        result = self.runner.invoke(cli, ["llm", "models"])
+
+        assert result.exit_code == 0
+        assert "caveat" in result.output
+        assert "ollama #14493" in result.output


### PR DESCRIPTION
## Summary
- Add curated model catalog (`src/ai_shell/models.py`) with 13 validated Ollama models across 3B-32B parameter range, annotated with role, size, censored/uncensored status, and caveats
- Add `ai-shell llm models` CLI command that cross-references catalog against config slots and Ollama state, with `--pulled`, `--role`, and `--uncensored` filters
- Includes mid-range 14B models (qwen3.5:14b, qwen2.5-coder:14b) as the 4090 sweet spot between 3B and 27-30B

## Test plan
- [x] 23 new tests covering catalog integrity, lookup, status classification, and all CLI flags
- [x] All 497 existing tests pass
- [x] 85.6% coverage (models.py at 100%)
- [x] Pre-commit (ruff, mypy) clean

Closes #90