### PR TITLE
feat(tools): add --openai-profile flag for multi-account switching

### DIFF
--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -211,6 +211,7 @@ def _get_manager(
     *,
     bedrock: bool = False,
     bedrock_profile: str = "",
+    openai_profile: str = "",
 ) -> tuple[ContainerManager, str, dict[str, str], AiShellConfig]:
     """Create ContainerManager from Click context and ensure dev container.
 
@@ -244,6 +245,7 @@ def _get_manager(
         aws_profile=config.ai_profile,
         aws_region=config.aws_region,
         bedrock_profile=bedrock_profile or config.bedrock_profile,
+        openai_profile=openai_profile or config.openai_profile,
     )
     return manager, container_name, exec_env, config
 
@@ -1097,6 +1099,12 @@ def claude(
 @click.option("--safe", is_flag=True, default=False, help="Run without permissive flags.")
 @click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
 @click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
+@click.option(
+    "--openai-profile",
+    "openai_profile",
+    default=None,
+    help="OpenAI .env profile name (resolves OPENAI_API_KEY_{NAME}).",
+)
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def codex(
@@ -1104,6 +1112,7 @@ def codex(
     safe,
     use_aws,
     cli_profile,
+    openai_profile,
     extra_args,
 ):
     """Launch Codex in the dev container."""
@@ -1115,6 +1124,7 @@ def codex(
         ctx,
         bedrock=use_bedrock,
         bedrock_profile=cli_profile or config.bedrock_profile,
+        openai_profile=openai_profile or config.openai_profile,
     )
 
     if use_bedrock:
@@ -1144,12 +1154,19 @@ def codex(
 @click.option("--safe", is_flag=True, default=False, help="Run without permissive flags.")
 @click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
 @click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
+@click.option(
+    "--openai-profile",
+    "openai_profile",
+    default=None,
+    help="OpenAI .env profile name (resolves OPENAI_API_KEY_{NAME}).",
+)
 @click.pass_context
 def opencode(
     ctx,
     safe,
     use_aws,
     cli_profile,
+    openai_profile,
 ):
     """Launch opencode in the dev container."""
     project = ctx.obj.get("project") if ctx.obj else None
@@ -1160,6 +1177,7 @@ def opencode(
         ctx,
         bedrock=use_bedrock,
         bedrock_profile=cli_profile or config.bedrock_profile,
+        openai_profile=openai_profile or config.openai_profile,
     )
 
     if use_bedrock:

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -197,6 +197,9 @@ class AiShellConfig:
     aws_region: str = ""  # Override AWS_REGION
     bedrock_profile: str = ""  # AWS profile for Bedrock LLM API calls
 
+    # OpenAI
+    openai_profile: str = ""  # Suffixed .env key name for multi-account switching
+
     # Claude options
     local_chrome: bool = False  # Attach Chrome DevTools MCP to project-scoped host Chrome
     pinned_image: bool = False  # When True, use version-matched image tag instead of latest
@@ -480,6 +483,11 @@ def _apply_config(config: AiShellConfig, path: Path) -> None:
     if "bedrock_profile" in aws:
         config.bedrock_profile = aws["bedrock_profile"]
 
+    # [openai] section
+    openai = data.get("openai", {})
+    if "profile" in openai:
+        config.openai_profile = openai["profile"]
+
     # [claude] section
     claude_sec = data.get("claude", {})
     if "provider" in claude_sec:
@@ -527,6 +535,7 @@ def _apply_env_vars(config: AiShellConfig) -> None:
         "AI_SHELL_AI_PROFILE": ("ai_profile", str),
         "AI_SHELL_AWS_REGION": ("aws_region", str),
         "AI_SHELL_BEDROCK_PROFILE": ("bedrock_profile", str),
+        "AI_SHELL_OPENAI_PROFILE": ("openai_profile", str),
         "AI_SHELL_CLAUDE_PROVIDER": ("claude_provider", str),
         "AI_SHELL_LOCAL_CHROME": ("local_chrome", bool),
         "AI_SHELL_PINNED_IMAGE": ("pinned_image", bool),

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -302,6 +302,7 @@ def build_dev_environment(
     aws_profile: str = "",
     aws_region: str = "",
     bedrock_profile: str = "",
+    openai_profile: str = "",
     team_mode: bool = False,
 ) -> dict[str, str]:
     """Build environment variables matching docker-compose.yml dev service.
@@ -314,6 +315,10 @@ def build_dev_environment(
     When *bedrock* is True, ``CLAUDE_CODE_USE_BEDROCK=1`` is injected and
     *bedrock_profile* (if set) overrides ``AWS_PROFILE`` so the LLM provider
     authenticates with the correct AWS account.
+
+    When *openai_profile* is set, the suffixed env vars
+    ``OPENAI_API_KEY_{NAME}`` and ``OPENAI_ORG_ID_{NAME}`` are resolved from
+    ``.env`` and injected as ``OPENAI_API_KEY`` / ``OPENAI_ORG_ID``.
 
     When *team_mode* is True, ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`` is
     injected to enable Claude Code's Agent Teams feature.
@@ -355,6 +360,18 @@ def build_dev_environment(
         env["CLAUDE_CODE_USE_BEDROCK"] = "1"
         if bedrock_profile:
             env["AWS_PROFILE"] = bedrock_profile
+
+    if openai_profile:
+        suffix = openai_profile.upper()
+        key_var = f"OPENAI_API_KEY_{suffix}"
+        api_key = dotenv.get(key_var)
+        if not api_key:
+            raise ValueError(f"OpenAI profile '{openai_profile}' requires {key_var} in .env")
+        env["OPENAI_API_KEY"] = api_key
+        org_var = f"OPENAI_ORG_ID_{suffix}"
+        org_id = dotenv.get(org_var)
+        if org_id:
+            env["OPENAI_ORG_ID"] = org_id
 
     if team_mode:
         env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"

--- a/src/ai_shell/templates/ai-shell.yaml
+++ b/src/ai_shell/templates/ai-shell.yaml
@@ -99,6 +99,20 @@ llm:
 #   region: us-east-1
 
 # -----------------------------------------------------------------------------
+# openai - OpenAI multi-account switching via suffixed .env keys.
+# -----------------------------------------------------------------------------
+# Store per-account API keys in .env:
+#   OPENAI_API_KEY_PERSONAL=sk-...
+#   OPENAI_API_KEY_AILLC=sk-...
+#   OPENAI_ORG_ID_AILLC=org-...
+#
+# Set a default profile here; override per-session with --openai-profile.
+# The profile name is uppercased to resolve OPENAI_API_KEY_{NAME}.
+#
+# openai:
+#   profile: personal
+
+# -----------------------------------------------------------------------------
 # claude - Claude Code backend selection. Uncomment to use Bedrock instead of
 # the Anthropic API. Equivalent per-session flag: `ai-shell claude --aws`.
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -125,6 +125,7 @@ class TestToolCommands:
         config.project_name = "my-project"
         config.claude_provider = ""
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -165,6 +166,7 @@ class TestToolCommands:
         config.project_name = "my-project"
         config.claude_provider = ""
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -200,6 +202,7 @@ class TestToolCommands:
         config.project_name = "my-project"
         config.claude_provider = ""
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -241,6 +244,7 @@ class TestToolCommands:
 
         config = MagicMock()
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -265,6 +269,7 @@ class TestToolCommands:
     ):
         config = MagicMock()
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -287,6 +292,7 @@ class TestToolCommands:
     ):
         config = MagicMock()
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -313,6 +319,7 @@ class TestToolCommands:
     ):
         config = MagicMock()
         config.bedrock_profile = "rd"
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -336,11 +343,60 @@ class TestToolCommands:
         assert call_kwargs["bedrock"] is True
         assert call_kwargs["bedrock_profile"] == "rd"
 
+    def test_codex_openai_profile_flag_passed_to_build_env(
+        self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        config = MagicMock()
+        config.bedrock_profile = ""
+        config.openai_profile = ""
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.extra_env = {}
+        config.project_dir = "/tmp/test"
+        mock_config.return_value = config
+
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        self.runner.invoke(cli, ["codex", "--openai-profile", "aillc"])
+
+        mock_build_env.assert_called_once()
+        call_kwargs = mock_build_env.call_args[1]
+        assert call_kwargs["openai_profile"] == "aillc"
+
+    def test_codex_openai_profile_from_config(
+        self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
+    ):
+        config = MagicMock()
+        config.bedrock_profile = ""
+        config.openai_profile = "personal"
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.extra_env = {}
+        config.project_dir = "/tmp/test"
+        mock_config.return_value = config
+
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        self.runner.invoke(cli, ["codex"])
+
+        mock_build_env.assert_called_once()
+        call_kwargs = mock_build_env.call_args[1]
+        assert call_kwargs["openai_profile"] == "personal"
+
     def test_codex_bedrock_preflight_called(
         self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
     ):
         config = MagicMock()
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -484,6 +540,7 @@ class TestToolCommands:
         config = MagicMock()
         config.claude_provider = ""
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -531,6 +588,7 @@ class TestToolCommands:
         config = MagicMock()
         config.claude_provider = ""
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -573,6 +631,7 @@ class TestToolCommands:
         config = MagicMock()
         config.claude_provider = ""
         config.bedrock_profile = ""
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}
@@ -622,6 +681,7 @@ class TestToolCommands:
         config = MagicMock()
         config.claude_provider = "aws"
         config.bedrock_profile = "rd"
+        config.openai_profile = ""
         config.ai_profile = ""
         config.aws_region = ""
         config.extra_env = {}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -538,6 +538,28 @@ provider = "aws"
             config = load_config(project_dir=tmp_path)
         assert config.ai_profile == "infra-acct"
 
+    def test_openai_profile_from_yaml(self, tmp_path):
+        (tmp_path / ".ai-shell.yaml").write_text("openai:\n  profile: personal\n")
+        config = load_config(project_dir=tmp_path)
+        assert config.openai_profile == "personal"
+
+    def test_openai_profile_from_toml(self, tmp_path):
+        (tmp_path / ".ai-shell.toml").write_bytes(b"""
+[openai]
+profile = "aillc"
+""")
+        config = load_config(project_dir=tmp_path)
+        assert config.openai_profile == "aillc"
+
+    def test_openai_profile_env_var(self, tmp_path):
+        with patch.dict("os.environ", {"AI_SHELL_OPENAI_PROFILE": "woxom"}):
+            config = load_config(project_dir=tmp_path)
+        assert config.openai_profile == "woxom"
+
+    def test_openai_profile_default_empty(self, tmp_path):
+        config = load_config(project_dir=tmp_path)
+        assert config.openai_profile == ""
+
     def test_env_overrides_toml(self, tmp_path):
         (tmp_path / ".ai-shell.toml").write_bytes(b"""
 [claude]

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from ai_shell.defaults import (
     CONTAINER_PREFIX,
     DEV_PORT_RANGE_SIZE,
@@ -333,6 +335,45 @@ class TestBuildDevEnvironmentBedrock:
             env = build_dev_environment()
         assert env["AWS_DEFAULT_REGION"] == "us-east-1"
         assert env["AWS_DEFAULT_REGION"] == env["AWS_REGION"]
+
+
+class TestBuildDevEnvironmentOpenAIProfile:
+    def test_openai_profile_sets_api_key(self, tmp_path):
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text("OPENAI_API_KEY_AILLC=sk-test-123\n")
+        env = build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+        assert env["OPENAI_API_KEY"] == "sk-test-123"
+
+    def test_openai_profile_sets_org_id_when_present(self, tmp_path):
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text("OPENAI_API_KEY_AILLC=sk-test-123\nOPENAI_ORG_ID_AILLC=org-abc\n")
+        env = build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+        assert env["OPENAI_API_KEY"] == "sk-test-123"
+        assert env["OPENAI_ORG_ID"] == "org-abc"
+
+    def test_openai_profile_no_org_id(self, tmp_path):
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text("OPENAI_API_KEY_PERSONAL=sk-personal\n")
+        env = build_dev_environment(project_dir=tmp_path, openai_profile="personal")
+        assert env["OPENAI_API_KEY"] == "sk-personal"
+        assert "OPENAI_ORG_ID" not in env
+
+    def test_openai_profile_uppercases_name(self, tmp_path):
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text("OPENAI_API_KEY_MYACCT=sk-myacct\n")
+        env = build_dev_environment(project_dir=tmp_path, openai_profile="myacct")
+        assert env["OPENAI_API_KEY"] == "sk-myacct"
+
+    def test_openai_profile_missing_key_raises(self, tmp_path):
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text("OPENAI_API_KEY_OTHER=sk-other\n")
+        with pytest.raises(ValueError, match="OPENAI_API_KEY_AILLC"):
+            build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+
+    def test_openai_profile_empty_string_is_noop(self):
+        env = build_dev_environment(openai_profile="")
+        assert "OPENAI_API_KEY" not in env
+        assert "OPENAI_ORG_ID" not in env
 
 
 class TestUvVenvPath:


### PR DESCRIPTION
## Summary
- Adds `--openai-profile` CLI flag to `codex` and `opencode` commands for switching between OpenAI accounts via suffixed `.env` keys (`OPENAI_API_KEY_{NAME}`, `OPENAI_ORG_ID_{NAME}`)
- Adds `openai_profile` config field (YAML `openai: profile:`, env var `AI_SHELL_OPENAI_PROFILE`) as a persistent default
- CLI flag overrides config; errors clearly if the suffixed API key is missing from `.env`

Closes #85

## Test plan
- [x] Config loading from YAML, TOML, env var, and default empty string
- [x] Environment builder resolves API key and optional org ID from `.env`
- [x] Uppercases profile name for key lookup
- [x] Raises ValueError when suffixed key is missing
- [x] Empty profile string is a no-op
- [x] CLI flag passes through to `build_dev_environment`
- [x] Config fallback used when no CLI flag provided
- [x] Pre-commit hooks pass
- [x] Full test suite passes (509 tests, 86% coverage)