### PR TITLE
fix(tools): default shell command to bash

### DIFF
--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -1265,18 +1265,14 @@ SUPPORTED_SHELLS: dict[str, str] = {
 def shell(ctx, shell_name):
     """Open an interactive shell in the dev container.
 
-    SHELL_NAME is one of bash, zsh, fish.  If omitted, an interactive
-    prompt asks which shell to launch.  All three shells come pre-configured
-    with modern defaults (Starship prompt, useful aliases, history tuning)
-    plus Oh My Zsh for zsh and Fisher for fish.
+    SHELL_NAME is one of bash, zsh, fish.  Defaults to bash if omitted.
+    All three shells come pre-configured with modern defaults (Starship
+    prompt, useful aliases, history tuning) plus Oh My Zsh for zsh and
+    Fisher for fish.
     """
     manager, name, exec_env, _config = _get_manager(ctx)
     if not shell_name:
-        shell_name = click.prompt(
-            "Choose shell",
-            type=click.Choice(list(SUPPORTED_SHELLS.keys()), case_sensitive=False),
-            default="bash",
-        )
+        shell_name = "bash"
     shell_name = shell_name.lower()
     shell_path = SUPPORTED_SHELLS[shell_name]
     console.print(f"[bold]Opening {shell_name} in {name}...[/bold]")

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -453,7 +453,7 @@ class TestToolCommands:
         cmd = mock_manager.exec_interactive.call_args[0][1]
         assert cmd == ["/usr/bin/fish", "-l"]
 
-    def test_shell_prompts_when_no_arg(
+    def test_shell_defaults_to_bash_when_no_arg(
         self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock
     ):
         mock_build_env.return_value = dict(TEST_EXEC_ENV)
@@ -462,11 +462,10 @@ class TestToolCommands:
         mock_manager.exec_interactive.side_effect = SystemExit(0)
         mock_manager_cls.return_value = mock_manager
 
-        # Simulate user selecting "zsh" at the prompt.
-        self.runner.invoke(cli, ["shell"], input="zsh\n")
+        self.runner.invoke(cli, ["shell"])
 
         cmd = mock_manager.exec_interactive.call_args[0][1]
-        assert cmd == ["/usr/bin/zsh", "-l"]
+        assert cmd == ["/bin/bash", "-l"]
 
     def test_shell_rejects_invalid(
         self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock


### PR DESCRIPTION
## Summary
- `ai-shell shell` now defaults to bash when no argument is provided, instead of showing an interactive prompt
- Updated tests to match the new default behavior

## Test plan
- [x] Pre-commit checks pass
- [x] All 509 tests pass with 86% coverage
- [x] Shell-specific tests verified: bash default, zsh explicit, fish explicit, invalid rejection