### PR TITLE
feat: isolate pre-commit cache via PRE_COMMIT_HOME and named volume (#99)

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -59,6 +59,20 @@ if [ -f "uv.lock" ]; then
     # Commands should be run with "uv run" prefix or use the activated venv
 fi
 
+# Install pre-commit hooks into the local .git/hooks directory.
+# Container-local: PRE_COMMIT_HOME points to a named volume so this does not
+# touch the Windows host's ~/.cache/pre-commit. Best-effort; never fail the
+# entrypoint because of pre-commit issues (set -e is active).
+if [ -f ".pre-commit-config.yaml" ] && [ -d ".git" ]; then
+    echo "===================================="
+    echo "Installing pre-commit hooks..."
+    echo "===================================="
+    uv run pre-commit install || true
+    echo "===================================="
+    echo "Pre-commit hooks installed!"
+    echo "===================================="
+fi
+
 if [ -f "package-lock.json" ]; then
     echo "===================================="
     echo "Installing Node.js dependencies..."

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -45,6 +45,8 @@ def uv_venv_path(repo_name: str, worktree_name: str | None = None) -> str:
 
 
 NPM_CACHE_VOLUME = "augint-shell-npm-cache"
+PRE_COMMIT_CACHE_VOLUME = "augint-shell-pre-commit-cache"
+PRE_COMMIT_CACHE_PATH = "/root/.cache/pre-commit-container"
 OLLAMA_DATA_VOLUME = "augint-shell-ollama-data"
 WEBUI_DATA_VOLUME = "augint-shell-webui-data"
 N8N_DATA_VOLUME = "augint-shell-n8n-data"
@@ -271,6 +273,17 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
         )
     )
 
+    # Named volume: pre-commit cache (shared across all projects).
+    # Isolates the container's hook environments from the Windows host's
+    # ~/.cache/pre-commit so the two installs don't clobber each other.
+    mounts.append(
+        Mount(
+            target=PRE_COMMIT_CACHE_PATH,
+            source=PRE_COMMIT_CACHE_VOLUME,
+            type="volume",
+        )
+    )
+
     return mounts
 
 
@@ -350,6 +363,7 @@ def build_dev_environment(
         "GITHUB_TOKEN": gh_token,
         "HUSKY": "0",
         "IS_SANDBOX": "1",
+        "PRE_COMMIT_HOME": PRE_COMMIT_CACHE_PATH,
     }
 
     # Mirror AWS_REGION to AWS_DEFAULT_REGION so both Node.js SDK paths resolve

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -13,6 +13,8 @@ from ai_shell.defaults import (
     N8N_DATA_VOLUME,
     NPM_CACHE_VOLUME,
     OLLAMA_CONTAINER,
+    PRE_COMMIT_CACHE_PATH,
+    PRE_COMMIT_CACHE_VOLUME,
     UV_CACHE_VOLUME,
     build_dev_environment,
     build_dev_mounts,
@@ -145,6 +147,22 @@ class TestBuildDevMounts:
         assert npm_mount is not None
         assert npm_mount.get("Source") == NPM_CACHE_VOLUME
 
+    def test_includes_pre_commit_cache_volume(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        pc_mount = None
+        for m in mounts:
+            if m.get("Target") == PRE_COMMIT_CACHE_PATH:
+                pc_mount = m
+                break
+
+        assert pc_mount is not None
+        assert pc_mount.get("Source") == PRE_COMMIT_CACHE_VOLUME
+        assert pc_mount.get("Type") == "volume"
+
     def test_skips_missing_optional_paths(self, tmp_path):
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -161,6 +179,7 @@ class TestBuildDevMounts:
         assert "/root/projects/test-project" in targets
         assert "/root/.cache/uv" in targets
         assert "/root/.npm" in targets
+        assert PRE_COMMIT_CACHE_PATH in targets
         assert "/root/.ssh" not in targets
         assert "/root/.claude" not in targets
         # No host path found → falls back to named volume (not a bind mount)
@@ -200,6 +219,10 @@ class TestBuildDevEnvironment:
     def test_includes_sandbox_flag(self):
         env = build_dev_environment()
         assert env["IS_SANDBOX"] == "1"
+
+    def test_sets_pre_commit_home(self):
+        env = build_dev_environment()
+        assert env["PRE_COMMIT_HOME"] == PRE_COMMIT_CACHE_PATH
 
     def test_includes_aws_region_default(self):
         with patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
## Summary
- Adds `PRE_COMMIT_CACHE_VOLUME` named volume mounted at `/root/.cache/pre-commit-container` so the container's pre-commit hook envs no longer collide with the Windows host cache (mirrors UV/NPM volume pattern).
- Sets `PRE_COMMIT_HOME` in the dev container env to point at that path.
- Runs `pre-commit install` from `docker-entrypoint.sh` when `.pre-commit-config.yaml` and `.git/` are both present.
- Closes #99.

## Notes
- The `defaults.py` env var + mount take effect immediately on next `ai-shell` container creation.
- The `pre-commit install` block in the entrypoint requires the next CI image build before it runs at container start.

## Test plan
- [x] `uv run pytest` (511 passed)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/`
- [ ] Manual: rebuild image, exec into a fresh container in a repo with `.pre-commit-config.yaml`, confirm hooks installed and `PRE_COMMIT_HOME` set