### PR TITLE
fix(ci): suppress pre-existing semgrep false positives blocking release

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,6 +134,7 @@ RUN mkdir -p /root/projects/${PROJECT_DIR} && \
 WORKDIR /root/projects/${PROJECT_DIR}
 
 # Switch to root and configure environment
+# nosemgrep: dockerfile.security.last-user-is-root.last-user-is-root
 USER root
 
 # Install zsh, fish, and bash-completion for multi-shell support

--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -80,9 +80,8 @@ def _manifest_exists(model_ref: str) -> bool | None:
     """
     namespace, name, tag = _parse_model_ref(model_ref)
     path = f"/v2/{namespace}/{name}/manifests/{tag}"
-    connection = HTTPSConnection(
-        _OLLAMA_REGISTRY_HOST, timeout=_MANIFEST_PROBE_TIMEOUT
-    )  # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
+    # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
+    connection = HTTPSConnection(_OLLAMA_REGISTRY_HOST, timeout=_MANIFEST_PROBE_TIMEOUT)
     try:
         connection.request(
             "HEAD",

--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -80,7 +80,7 @@ def _manifest_exists(model_ref: str) -> bool | None:
     """
     namespace, name, tag = _parse_model_ref(model_ref)
     path = f"/v2/{namespace}/{name}/manifests/{tag}"
-    connection = HTTPSConnection(_OLLAMA_REGISTRY_HOST, timeout=_MANIFEST_PROBE_TIMEOUT)
+    connection = HTTPSConnection(_OLLAMA_REGISTRY_HOST, timeout=_MANIFEST_PROBE_TIMEOUT)  # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
     try:
         connection.request(
             "HEAD",

--- a/src/ai_shell/cli/commands/llm.py
+++ b/src/ai_shell/cli/commands/llm.py
@@ -80,7 +80,9 @@ def _manifest_exists(model_ref: str) -> bool | None:
     """
     namespace, name, tag = _parse_model_ref(model_ref)
     path = f"/v2/{namespace}/{name}/manifests/{tag}"
-    connection = HTTPSConnection(_OLLAMA_REGISTRY_HOST, timeout=_MANIFEST_PROBE_TIMEOUT)  # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
+    connection = HTTPSConnection(
+        _OLLAMA_REGISTRY_HOST, timeout=_MANIFEST_PROBE_TIMEOUT
+    )  # nosemgrep: python.lang.security.audit.httpsconnection-detected.httpsconnection-detected
     try:
         connection.request(
             "HEAD",

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -144,7 +144,9 @@ def unique_project_name(path: Path, project_name: str | None = None) -> str:
     collisions between repos with the same leaf directory name.
     """
     slug = _sanitize_name((project_name or path.resolve().name).lower())
-    digest = sha1(str(path.resolve()).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    digest = sha1(str(path.resolve()).encode("utf-8"), usedforsecurity=False).hexdigest()[
+        :8
+    ]  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
     return f"{slug}-{digest}"
 
 
@@ -171,7 +173,9 @@ def project_dev_port(
     for the same container port, so multiple projects can run simultaneously.
     """
     slug = unique_project_name(project_dir, project_name)
-    digest = sha1(f"{slug}:{container_port}".encode(), usedforsecurity=False).hexdigest()  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    digest = (
+        sha1(f"{slug}:{container_port}".encode(), usedforsecurity=False).hexdigest()
+    )  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
     return DEV_PORT_RANGE_START + (int(digest[:8], 16) % DEV_PORT_RANGE_SIZE)
 
 

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -144,7 +144,7 @@ def unique_project_name(path: Path, project_name: str | None = None) -> str:
     collisions between repos with the same leaf directory name.
     """
     slug = _sanitize_name((project_name or path.resolve().name).lower())
-    digest = sha1(str(path.resolve()).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
+    digest = sha1(str(path.resolve()).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
     return f"{slug}-{digest}"
 
 
@@ -171,7 +171,7 @@ def project_dev_port(
     for the same container port, so multiple projects can run simultaneously.
     """
     slug = unique_project_name(project_dir, project_name)
-    digest = sha1(f"{slug}:{container_port}".encode(), usedforsecurity=False).hexdigest()
+    digest = sha1(f"{slug}:{container_port}".encode(), usedforsecurity=False).hexdigest()  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
     return DEV_PORT_RANGE_START + (int(digest[:8], 16) % DEV_PORT_RANGE_SIZE)
 
 

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -144,9 +144,8 @@ def unique_project_name(path: Path, project_name: str | None = None) -> str:
     collisions between repos with the same leaf directory name.
     """
     slug = _sanitize_name((project_name or path.resolve().name).lower())
-    digest = sha1(str(path.resolve()).encode("utf-8"), usedforsecurity=False).hexdigest()[
-        :8
-    ]  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    digest = sha1(str(path.resolve()).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
     return f"{slug}-{digest}"
 
 
@@ -173,9 +172,8 @@ def project_dev_port(
     for the same container port, so multiple projects can run simultaneously.
     """
     slug = unique_project_name(project_dir, project_name)
-    digest = (
-        sha1(f"{slug}:{container_port}".encode(), usedforsecurity=False).hexdigest()
-    )  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    digest = sha1(f"{slug}:{container_port}".encode(), usedforsecurity=False).hexdigest()
     return DEV_PORT_RANGE_START + (int(digest[:8], 16) % DEV_PORT_RANGE_SIZE)
 
 

--- a/src/ai_shell/local_chrome.py
+++ b/src/ai_shell/local_chrome.py
@@ -107,9 +107,8 @@ def _chrome_profile_dir(project_name: str, project_dir: str | Path | None = None
 def _project_debug_port(project_name: str, project_dir: str | Path | None = None) -> int:
     """Return a stable per-project Chrome remote debugging port."""
     slug = _project_slug(project_name, project_dir)
-    digest = (
-        sha1(slug.encode("utf-8"), usedforsecurity=False).hexdigest()
-    )  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    digest = sha1(slug.encode("utf-8"), usedforsecurity=False).hexdigest()
     return CHROME_DEBUG_PORT_RANGE_START + (int(digest[:8], 16) % CHROME_DEBUG_PORT_RANGE_SIZE)
 
 

--- a/src/ai_shell/local_chrome.py
+++ b/src/ai_shell/local_chrome.py
@@ -107,7 +107,9 @@ def _chrome_profile_dir(project_name: str, project_dir: str | Path | None = None
 def _project_debug_port(project_name: str, project_dir: str | Path | None = None) -> int:
     """Return a stable per-project Chrome remote debugging port."""
     slug = _project_slug(project_name, project_dir)
-    digest = sha1(slug.encode("utf-8"), usedforsecurity=False).hexdigest()  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    digest = (
+        sha1(slug.encode("utf-8"), usedforsecurity=False).hexdigest()
+    )  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
     return CHROME_DEBUG_PORT_RANGE_START + (int(digest[:8], 16) % CHROME_DEBUG_PORT_RANGE_SIZE)
 
 

--- a/src/ai_shell/local_chrome.py
+++ b/src/ai_shell/local_chrome.py
@@ -107,7 +107,7 @@ def _chrome_profile_dir(project_name: str, project_dir: str | Path | None = None
 def _project_debug_port(project_name: str, project_dir: str | Path | None = None) -> int:
     """Return a stable per-project Chrome remote debugging port."""
     slug = _project_slug(project_name, project_dir)
-    digest = sha1(slug.encode("utf-8"), usedforsecurity=False).hexdigest()
+    digest = sha1(slug.encode("utf-8"), usedforsecurity=False).hexdigest()  # nosemgrep: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
     return CHROME_DEBUG_PORT_RANGE_START + (int(digest[:8], 16) % CHROME_DEBUG_PORT_RANGE_SIZE)
 
 


### PR DESCRIPTION
## Summary
Release pipeline on `main` was failing (also failed on the prior `ci(deps)` push on 922e2c0, blocking PyPI publish). All 5 Semgrep findings are false positives on existing code:

- `docker/Dockerfile:137` — `USER root` is intentional for the dev container.
- `src/ai_shell/cli/commands/llm.py:83` — stdlib `HTTPSConnection`, version-specific advisory only.
- `src/ai_shell/defaults.py:147,174` + `src/ai_shell/local_chrome.py:110` — `sha1(..., usedforsecurity=False)` is explicitly marked non-cryptographic (container-name / port hashing).

Adds inline `# nosemgrep: <rule-id>` suppressions on each of the 5 lines. No functional changes.

## Test plan
- [x] `uv run ruff check src/`
- [ ] CI: Security job passes on this PR, then automerges to main
- [ ] semantic-release runs on main push, publishes to PyPI