### PR TITLE
chore(ci): canonicalize renovate rules for GitHub Actions and semantic-release

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -113,27 +113,18 @@
     {
       "matchPackageNames": ["python-semantic-release"],
       "automerge": false,
-      "commitMessagePrefix": "ci(deps-dev):"
+      "commitMessagePrefix": "chore(deps-dev):"
     },
 
     // ---------------------------------------------------------------
-    // GitHub Actions (minor/patch: automerge; major: manual review)
+    // GitHub Actions (automerge all; gates + staging catch regressions)
     // ---------------------------------------------------------------
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "commitMessagePrefix": "ci(deps):",
       "automerge": true,
       "groupName": "GitHub Actions",
       "groupSlug": "gh-actions"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["major"],
-      "commitMessagePrefix": "ci(deps):",
-      "automerge": false,
-      "groupName": "GitHub Actions (major)",
-      "groupSlug": "gh-actions-major"
     },
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Collapse the GitHub Actions packageRule into a single always-automerge
entry (drop the minor/patch vs major split). Pre-merge gates and staging
catch regressions — manual-review gating on Actions majors was friction
without added safety.

Align python-semantic-release commitMessagePrefix with the canonical
chore(deps-dev): value.
