### PR TITLE
feat: add pi coding agent as fully supported tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ CLI commands (cli/commands/)
 
 ### Mount assembly
 
-Dev containers mount: project dir, UV cache volume (shared), and conditionally: `~/.claude`, `~/.codex`, `~/.ssh` (ro), `~/.aws`, `~/.config/gh`, `~/.gitconfig` (ro), `~/projects/CLAUDE.md` (ro), Docker socket (ro), plus `extra_volumes` from config.
+Dev containers mount: project dir, UV cache volume (shared), and conditionally: `~/.claude`, `~/.codex`, `~/.pi`, `~/.ssh` (ro), `~/.aws`, `~/.config/gh`, `~/.gitconfig` (ro), `~/projects/CLAUDE.md` (ro), Docker socket (ro), plus `extra_volumes` from config.
 
 ### Environment assembly
 
@@ -60,6 +60,10 @@ Priority: `extra_env` > `.env` file > `os.environ` > defaults. AWS IAM keys are 
 ### Claude retry logic
 
 Default: runs with `-c` (continue previous conversation). If it fails fast (< 5 seconds), retries without `-c` (assumes no prior conversation exists).
+
+### Pi integration
+
+Pi (`@mariozechner/pi-coding-agent`) is a provider-agnostic terminal coding agent installed via npm. It connects to Ollama via `models.json` (template in `src/ai_shell/templates/pi/`). The `ai-shell pi` command checks Ollama is running before launch. Config persists via `~/.pi` bind mount. Supports `--aws` (Bedrock), `--openai-profile`, and `--login` (OAuth).
 
 ### Scaffold system
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,6 +103,9 @@ RUN npm install -g @openai/codex
 RUN curl -fsSL https://opencode.ai/install | bash
 ENV PATH="/root/.opencode/bin:${PATH}"
 
+# Install pi (terminal coding agent, provider-agnostic)
+RUN npm install -g @mariozechner/pi-coding-agent
+
 # Install aider (alternative local coding assistant)
 RUN curl -LsSf https://aider.chat/install.sh | sh
 

--- a/docker/update-tools.sh
+++ b/docker/update-tools.sh
@@ -20,7 +20,7 @@ LOG_DIR="/var/log/ai-shell"
 LOCK_FILE="/var/run/ai-shell/update.lock"
 DEFAULT_TTL=21600  # 6 hours in seconds
 
-ALL_TOOLS="claude codex aider opencode npm-tools"
+ALL_TOOLS="claude codex aider opencode pi npm-tools"
 
 # ---- argument parsing ----------------------------------------------------
 ACTION=""
@@ -94,6 +94,11 @@ _update_opencode() {
     curl -fsSL https://opencode.ai/install | bash 2>&1 || true
 }
 
+_update_pi() {
+    _log "Updating pi..."
+    npm install -g @mariozechner/pi-coding-agent@latest 2>&1 || true
+}
+
 _update_npm_tools() {
     _log "Updating npm tools (aws-cdk, playwright-cli, agent-browser)..."
     npm install -g aws-cdk@latest @playwright/cli@latest agent-browser@latest 2>&1 || true
@@ -106,6 +111,7 @@ _update_tool() {
         codex)      _update_codex     ;;
         aider)      _update_aider     ;;
         opencode)   _update_opencode  ;;
+        pi)         _update_pi        ;;
         npm-tools)  _update_npm_tools ;;
         *)
             _log "Unknown tool: $tool"

--- a/src/ai_shell/cli/__main__.py
+++ b/src/ai_shell/cli/__main__.py
@@ -9,7 +9,7 @@ from ai_shell import __version__
 from ai_shell.cli import CONTEXT_SETTINGS
 from ai_shell.cli.commands.llm import llm_group
 from ai_shell.cli.commands.manage import manage_group
-from ai_shell.cli.commands.tools import aider, claude, codex, init, opencode, shell
+from ai_shell.cli.commands.tools import aider, claude, codex, init, opencode, pi, shell
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -43,6 +43,7 @@ def cli(ctx, project, verbose, orig_image, skip_updates):
 cli.add_command(claude)
 cli.add_command(codex)
 cli.add_command(opencode)
+cli.add_command(pi)
 cli.add_command(aider)
 cli.add_command(shell)
 cli.add_command(init)

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -1,4 +1,4 @@
-"""AI tool subcommands: claude, codex, opencode, aider, shell."""
+"""AI tool subcommands: claude, codex, opencode, pi, aider, shell."""
 
 from __future__ import annotations
 
@@ -1269,6 +1269,94 @@ def opencode(
             # (uncensored) slot in the OpenCode model picker at runtime.
             cmd.extend(["--model", f"ollama/{config.primary_coding_model}"])
         console.print(f"[bold]Launching opencode{bedrock_label}{openai_label} in {name}...[/bold]")
+    manager.exec_interactive(name, cmd, extra_env=exec_env, typeahead=typeahead.bytes())
+
+
+def _check_ollama_running(container_name: str) -> None:
+    """Verify the Ollama container is reachable from the dev container.
+
+    Raises :class:`click.ClickException` with setup instructions on failure.
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container_name,
+            "curl",
+            "-sf",
+            "http://host.docker.internal:11434/api/version",
+        ],
+        capture_output=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(
+            "Ollama is not running. Pi requires a running Ollama instance.\n\n"
+            "  Start the LLM stack:  ai-shell llm up\n"
+            "  Pull models:          ai-shell llm pull\n\n"
+            "Once Ollama is running, retry:  ai-shell pi"
+        )
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option("--aws", "use_aws", is_flag=True, default=False, help="Use Amazon Bedrock.")
+@click.option("--profile", "cli_profile", default=None, help="AWS profile for Bedrock auth.")
+@click.option(
+    "--openai-profile",
+    "openai_profile",
+    default=None,
+    help=(
+        "OpenAI .env profile name for multi-account switching.  "
+        "Store per-account keys in .env as OPENAI_API_KEY_{NAME} "
+        "(e.g. OPENAI_API_KEY_WORK, OPENAI_API_KEY_PERSONAL).  "
+        "Optionally add OPENAI_ORG_ID_{NAME}.  "
+        "Set a default in .ai-shell.yaml under openai.profile or "
+        "via AI_SHELL_OPENAI_PROFILE env var."
+    ),
+)
+@click.option("--login", "do_login", is_flag=True, default=False, help="Run pi login for OAuth.")
+@click.pass_context
+def pi(ctx, use_aws, cli_profile, openai_profile, do_login):
+    """Launch pi coding agent in the dev container."""
+    with capture_typeahead() as typeahead:
+        project = ctx.obj.get("project") if ctx.obj else None
+        config = load_config(project_override=project, project_dir=Path.cwd())
+        use_bedrock = use_aws
+
+        manager, name, exec_env, config = _get_manager(
+            ctx,
+            bedrock=use_bedrock,
+            bedrock_profile=cli_profile or config.bedrock_profile,
+            openai_profile=openai_profile or config.openai_profile,
+        )
+
+        if do_login:
+            console.print("[bold]Running pi login...[/bold]")
+            manager.exec_interactive(name, ["pi", "login"], extra_env=exec_env)
+
+        if use_bedrock:
+            profile_label = exec_env.get("AWS_PROFILE", "default")
+            region_label = exec_env.get("AWS_REGION", "us-east-1")
+            bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
+            console.print(
+                f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
+            )
+            _check_bedrock_access(name, exec_env)
+        else:
+            bedrock_label = ""
+            _check_ollama_running(name)
+
+        resolved_openai_profile = openai_profile or config.openai_profile
+        openai_label = (
+            f" (OpenAI profile={resolved_openai_profile})" if resolved_openai_profile else ""
+        )
+
+        manager.ensure_tool_fresh(name, "pi")
+
+        cmd = ["pi"]
+        if not use_bedrock and not resolved_openai_profile:
+            cmd.extend(["--model", f"ollama/{config.primary_coding_model}"])
+        console.print(f"[bold]Launching pi{bedrock_label}{openai_label} in {name}...[/bold]")
     manager.exec_interactive(name, cmd, extra_env=exec_env, typeahead=typeahead.bytes())
 
 

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -204,6 +204,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
         (home / ".codex", "/root/.codex", False),
         (home / ".claude", "/root/.claude", False),
         (home / ".claude.json", "/root/.claude.json", False),
+        (home / ".pi", "/root/.pi", False),
         (home / "projects" / "CLAUDE.md", "/root/projects/CLAUDE.md", True),
         (home / ".ssh", "/root/.ssh", True),
         (home / ".gitconfig", "/root/.gitconfig.windows", True),

--- a/src/ai_shell/templates/ai-shell.yaml
+++ b/src/ai_shell/templates/ai-shell.yaml
@@ -10,7 +10,7 @@
 # -----------------------------------------------------------------------------
 # Four role-specific model slots. Primary = best-available; secondary =
 # best uncensored (abliterated) alternative of the same base. Chat slots
-# route to Open WebUI (DEFAULT_MODELS); coding slots route to OpenCode /
+# route to Open WebUI (DEFAULT_MODELS); coding slots route to Pi / OpenCode /
 # Aider (--model). `ai-shell llm pull` pulls all 4 slots plus any
 # `extra_models` entries, deduped. See README for per-slot rationale and
 # caveats (Qwen3.5 Ollama tool-call bug, num_ctx trap, tool-count cliff).

--- a/src/ai_shell/templates/pi/models.json
+++ b/src/ai_shell/templates/pi/models.json
@@ -1,0 +1,16 @@
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://host.docker.internal:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [
+        { "id": "qwen3-coder:30b-a3b-q4_K_M" },
+        { "id": "huihui_ai/qwen3-coder-abliterated:30b-a3b-instruct-q4_K_M" },
+        { "id": "devstral:24b" },
+        { "id": "qwen3.5:27b" },
+        { "id": "qwen3.5:9b" }
+      ]
+    }
+  }
+}

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -522,6 +522,75 @@ class TestToolCommands:
         assert "--model" in cmd
         assert "--restore-chat-history" in cmd
 
+    @patch("ai_shell.cli.commands.tools._check_ollama_running")
+    def test_pi_default_uses_ollama_model(
+        self,
+        mock_check_ollama,
+        mock_config,
+        mock_manager_cls,
+        mock_build_env,
+        mock_check_bedrock,
+    ):
+        mock_check_ollama.return_value = None
+        mock_build_env.return_value = dict(TEST_EXEC_ENV)
+        config = MagicMock()
+        config.primary_coding_model = "qwen3-coder:30b-a3b-q4_K_M"
+        config.bedrock_profile = ""
+        config.openai_profile = ""
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.extra_env = {}
+        config.project_dir = "/tmp/test"
+        mock_config.return_value = config
+
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        self.runner.invoke(cli, ["pi"])
+
+        cmd = mock_manager.exec_interactive.call_args[0][1]
+        assert cmd[0] == "pi"
+        assert "--model" in cmd
+        assert "ollama/qwen3-coder:30b-a3b-q4_K_M" in cmd
+        mock_check_ollama.assert_called_once()
+
+    @patch("ai_shell.cli.commands.tools._check_ollama_running")
+    def test_pi_bedrock_skips_ollama_check(
+        self,
+        mock_check_ollama,
+        mock_config,
+        mock_manager_cls,
+        mock_build_env,
+        mock_check_bedrock,
+    ):
+        bedrock_env = dict(TEST_EXEC_ENV)
+        bedrock_env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        bedrock_env["AWS_PROFILE"] = "rd"
+        mock_build_env.return_value = bedrock_env
+        config = MagicMock()
+        config.primary_coding_model = "qwen3-coder:30b-a3b-q4_K_M"
+        config.bedrock_profile = ""
+        config.openai_profile = ""
+        config.ai_profile = ""
+        config.aws_region = ""
+        config.extra_env = {}
+        config.project_dir = "/tmp/test"
+        mock_config.return_value = config
+
+        mock_manager = MagicMock()
+        mock_manager.ensure_dev_container.return_value = "augint-shell-test-dev"
+        mock_manager.exec_interactive.side_effect = SystemExit(0)
+        mock_manager_cls.return_value = mock_manager
+
+        self.runner.invoke(cli, ["pi", "--aws"])
+
+        mock_check_ollama.assert_not_called()
+        cmd = mock_manager.exec_interactive.call_args[0][1]
+        assert cmd[0] == "pi"
+        assert "--model" not in cmd
+
     @patch("ai_shell.cli.commands.tools._inject_mcp_config")
     @patch("ai_shell.local_chrome.start_chrome_proxy")
     @patch("ai_shell.local_chrome.ensure_host_chrome", return_value=9222)


### PR DESCRIPTION
## Summary
- Adds `ai-shell pi` command with full provider support (Ollama default, `--aws` for Bedrock, `--openai-profile`, `--login` for OAuth)
- Installs pi in Docker image, adds to auto-update roster, persists `~/.pi` config via bind mount
- Includes Ollama health check with actionable error message when LLM stack isn't running
- Ships `models.json` template pre-configured for all model slots via `host.docker.internal`

## Test plan
- [x] `uv run pytest` (519 passed)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/`
- [x] `uv run pre-commit run --all-files`
- [ ] Manual: `ai-shell pi` with Ollama running, confirm pi launches with correct model
- [ ] Manual: `ai-shell pi` without Ollama, confirm helpful error message
- [ ] Manual: `ai-shell pi --aws` with valid Bedrock credentials
- [ ] Manual: `ai-shell pi --login` runs interactive OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)