### PR TITLE
feat: Plannotator and Pi Studio plugin runtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ docs/
 ai-shell.toml
 .ai-shell.yaml
 **/.worktrees
+.playwright-mcp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,6 +105,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# Install Bun (required by Plannotator OpenCode plugin)
+RUN curl -fsSL https://bun.sh/install | bash && \
+    ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
+    ln -s /root/.bun/bin/bunx /usr/local/bin/bunx
+
 # Install AWS CDK CLI
 RUN npm install -g aws-cdk
 
@@ -125,9 +130,12 @@ RUN npm install -g @mariozechner/pi-coding-agent
 # Install aider (alternative local coding assistant)
 RUN curl -LsSf https://aider.chat/install.sh | sh
 
-# Install pandoc (required by pi-studio for Markdown/LaTeX rendering)
+# Install pandoc + xelatex (required by pi-studio for Markdown/LaTeX
+# rendering and PDF export via /studio-pdf).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pandoc \
+    texlive-xetex \
+    texlive-fonts-recommended \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Playwright with Chrome and ALL dependencies

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -122,13 +122,15 @@ if [ -f ".pi/settings.json" ] && command -v pi >/dev/null 2>&1; then
         echo "Pi packages installed!"
         echo "===================================="
 
-        # Apply pi-studio container patch: bind to 0.0.0.0 so the web UI is
-        # reachable from the Windows host.
+        # Apply pi-studio container patch: bind to 0.0.0.0 on a fixed port
+        # (31415) so Docker can map it to a deterministic host port and the
+        # web UI is reachable from the host. Pi-studio hard-codes
+        # `server.listen(0, "127.0.0.1")` and reads no env vars for this.
         _STUDIO_INDEX=$(find /root/.pi -path '*/pi-studio/index.ts' 2>/dev/null | head -1)
         if [ -n "$_STUDIO_INDEX" ]; then
-            if grep -q '"127.0.0.1"' "$_STUDIO_INDEX" 2>/dev/null; then
-                sed -i 's/"127\.0\.0\.1"/"0.0.0.0"/g' "$_STUDIO_INDEX"
-                echo "Patched pi-studio to listen on 0.0.0.0"
+            if grep -q 'server\.listen(0, "127\.0\.0\.1")' "$_STUDIO_INDEX" 2>/dev/null; then
+                sed -i 's|server\.listen(0, "127\.0\.0\.1")|server.listen(31415, "0.0.0.0")|g' "$_STUDIO_INDEX"
+                echo "Patched pi-studio to listen on 0.0.0.0:31415"
             fi
         fi
     fi

--- a/docker/motd.sh
+++ b/docker/motd.sh
@@ -362,6 +362,32 @@ if [ -n "$AUGINT_DEV_PORTS" ]; then
     done
     printf "${AMBER}│${RESET}    ${DIM_ITALIC}Start a dev server inside the container, open the mapped URL in your host browser.${RESET}\n"
 fi
+
+# Plannotator UI (labeled shortcut for the OpenCode plan-review plugin)
+if [ -n "$AUGINT_DEV_PORTS" ]; then
+    IFS=',' read -ra _port_pairs <<< "$AUGINT_DEV_PORTS"
+    for _pair in "${_port_pairs[@]}"; do
+        _cport="${_pair%%:*}"
+        _hport="${_pair##*:}"
+        if [ "$_cport" = "19432" ]; then
+            printf "${AMBER}│${RESET}    ${MAUVE}Plannotator UI:${RESET}  ${CYAN}http://localhost:%s${RESET}\n" "$_hport"
+            break
+        fi
+    done
+fi
+
+# Pi Studio UI (labeled shortcut for the pi-studio extension)
+if [ -n "$AUGINT_DEV_PORTS" ]; then
+    IFS=',' read -ra _port_pairs <<< "$AUGINT_DEV_PORTS"
+    for _pair in "${_port_pairs[@]}"; do
+        _cport="${_pair%%:*}"
+        _hport="${_pair##*:}"
+        if [ "$_cport" = "31415" ]; then
+            printf "${AMBER}│${RESET}    ${MAUVE}Pi Studio:${RESET}      ${CYAN}http://localhost:%s${RESET}  ${DIM_ITALIC}(run /studio in pi to get the tokenized URL, then swap :31415 for :%s)${RESET}\n" "$_hport" "$_hport"
+            break
+        fi
+    done
+fi
 echo ""
 
 # ── Prompt legend ─────────────────────────────────────────────────────────────

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -91,7 +91,7 @@ DEFAULT_WHISPER_MODEL = "Systran/faster-distil-whisper-large-v3"
 DEFAULT_VOICE_AGENT_PORT = 8010
 DEFAULT_COMFYUI_PORT = 8188
 DEFAULT_KOKORO_VOICE = "af_bella"
-DEFAULT_DEV_PORTS = [3000, 4096, 4200, 5000, 5173, 5678, 8000, 8080, 8888]
+DEFAULT_DEV_PORTS = [3000, 4096, 4200, 5000, 5173, 5678, 8000, 8080, 8888, 19432, 31415]
 
 # Deterministic dev port mapping (avoids Chrome debug range 40000-60000)
 DEV_PORT_RANGE_START = 10000
@@ -201,7 +201,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
 
     # Ensure directories that tools need for persistent config exist on the
     # host so bind mounts aren't silently skipped.
-    for d in (".pi", ".augint"):
+    for d in (".pi", ".augint", ".plannotator"):
         (home / d).mkdir(parents=True, exist_ok=True)
 
     # Optional bind mounts — skip if source doesn't exist
@@ -211,6 +211,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
         (home / ".claude.json", "/root/.claude.json", False),
         (home / ".pi", "/root/.pi", False),
         (home / ".augint", "/root/.augint", False),
+        (home / ".plannotator", "/root/.plannotator", False),
         (home / ".ssh", "/root/.ssh", True),
         (home / ".gitconfig", "/root/.gitconfig.windows", True),
         (home / ".aws", "/root/.aws", False),
@@ -424,6 +425,9 @@ def build_dev_environment(
         "IS_SANDBOX": "1",
         "PRE_COMMIT_HOME": PRE_COMMIT_CACHE_PATH,
         "PI_STUDIO_HOST": "0.0.0.0",  # nosec B104
+        "PLANNOTATOR_REMOTE": "1",
+        "PLANNOTATOR_PORT": "19432",
+        "PLANNOTATOR_BROWSER": "echo",
     }
 
     if env_file is not None:


### PR DESCRIPTION
## Summary

- **Plannotator** (closes #113): install Bun, pin port 19432, inject `PLANNOTATOR_*` env vars, persist `~/.plannotator/`, add labeled MOTD line.
- **Pi Studio**: pin to fixed port 31415 by extending the entrypoint sed (pi-studio hard-codes `server.listen(0, "127.0.0.1")` and reads no env vars — random ports made Docker port-mapping ineffective). Install `texlive-xetex` for `/studio-pdf`. Add labeled MOTD line.
- Drop unused `.playwright-mcp` cache from git tracking.

## Notes

- Image grows ~250–400 MB from `texlive-xetex` + `texlive-fonts-recommended`. Skipped `mermaid-cli` (heavy, only needed for diagram blocks in PDFs).
- Pi Studio's `/studio --status` URL still prints `127.0.0.1:31415`. Users translate to `localhost:<host_port>` (printed in MOTD), preserving the `?token=...` parameter.
- Existing `PI_STUDIO_HOST` env var in `defaults.py` is now confirmed inert (pi-studio source ignores it). Left in place as harmless.

## Test plan

- [ ] `docker build` succeeds locally
- [ ] `bun --version` works inside the dev container
- [ ] `xelatex --version` works inside the dev container
- [ ] After `pi install pi-studio`, `/studio` opens a server on container port 31415 reachable via the host-mapped port shown in MOTD
- [ ] `PLANNOTATOR_*` env vars present in container
- [ ] `~/.plannotator` mounted and writable
- [ ] MOTD displays both the Plannotator and Pi Studio labeled URLs