### PR TITLE
feat: bind-mount ~/.config into dev containers

### DIFF
--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -206,6 +206,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
 
     # Optional bind mounts — skip if source doesn't exist
     optional_binds: list[tuple[Path, str, bool]] = [
+        (home / ".config", "/root/.config", False),
         (home / ".codex", "/root/.codex", False),
         (home / ".claude", "/root/.claude", False),
         (home / ".claude.json", "/root/.claude.json", False),


### PR DESCRIPTION
## Summary
- Adds host `~/.config` to `/root/.config` in dev containers so XDG-based tool configs (opencode, fish, gcloud, etc.) persist
- Skipped if the host directory doesn't exist
- Existing nested `~/.config/gh` mount still wins for GitHub CLI auth, including the WSL2 APPDATA fallback

## Test plan
- [x] `pytest tests/unit/test_defaults.py::TestBuildDevMounts` passes
- [ ] Container picks up host `~/.config` at runtime