### PR TITLE
fix: --env loads all .env vars into dev containers

### DIFF
--- a/src/ai_shell/cli/commands/manage.py
+++ b/src/ai_shell/cli/commands/manage.py
@@ -115,7 +115,7 @@ def manage_pull(ctx):
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.pass_context
 def manage_env(ctx, use_aws, env_file):

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -1079,7 +1079,7 @@ def _launch_multi(
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
@@ -1186,7 +1186,7 @@ def claude(
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
@@ -1325,7 +1325,7 @@ def _opencode_setup(
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.pass_context
 def opencode(
@@ -1598,7 +1598,7 @@ def _ensure_pi_ollama_provider(config: AiShellConfig) -> None:
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.pass_context
 def pi(ctx, use_aws, cli_profile, openai_profile, do_login, doom, env_file):
@@ -1680,7 +1680,7 @@ SUPPORTED_SHELLS: dict[str, str] = {
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.argument(
     "shell_name",

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -206,6 +206,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
 
     # Optional bind mounts — skip if source doesn't exist
     optional_binds: list[tuple[Path, str, bool]] = [
+        (home / ".config", "/root/.config", False),
         (home / ".codex", "/root/.codex", False),
         (home / ".claude", "/root/.claude", False),
         (home / ".claude.json", "/root/.claude.json", False),

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -323,9 +323,12 @@ def _load_layered_dotenv(
     project_dir: Path | None = None,
     env_file: Path | None = None,
 ) -> dict[str, str | None]:
-    """Load layered .env files: ~/.augint/.env < project .env < explicit env_file.
+    """Load layered .env files.
 
-    Returns a merged dict. Later layers override earlier ones.
+    ``~/.augint/.env`` always loads (global augint suite config). The project
+    ``./.env`` and explicit *env_file* only load when *env_file* is given
+    (i.e. user passed ``--env`` on the CLI). Later layers override earlier
+    ones.
     """
     from dotenv import dotenv_values
 
@@ -335,12 +338,15 @@ def _load_layered_dotenv(
     if global_path.is_file():
         layers.update(dotenv_values(global_path))
 
+    if env_file is None:
+        return layers
+
     if project_dir is not None:
         project_path = project_dir / ".env"
-        if project_path.is_file():
+        if project_path.is_file() and project_path.resolve() != env_file.resolve():
             layers.update(dotenv_values(project_path))
 
-    if env_file is not None and env_file.is_file():
+    if env_file.is_file():
         layers.update(dotenv_values(env_file))
 
     return layers
@@ -382,14 +388,15 @@ def build_dev_environment(
 ) -> dict[str, str]:
     """Build environment variables matching docker-compose.yml dev service.
 
-    Loads layered .env files (``~/.augint/.env`` then project ``.env``),
-    then falls back to host environment variables and hardcoded defaults.
+    ``~/.augint/.env`` always loads (global augint suite config). The project
+    ``./.env`` only loads when *env_file* is given (``--env`` on the CLI);
+    when loaded, **all** of its keys flow through to the container.
 
-    Priority (highest wins): extra_env > .env files > os.environ > defaults.
+    Priority (highest wins): extra_env > CLI flags > ``./.env`` (when ``--env``)
+    > ``~/.augint/.env`` > host ``os.environ`` (allowlisted) > defaults.
 
-    GitHub auth defaults to SSO via the ``~/.config/gh`` bind mount.
-    ``GH_TOKEN`` / ``GITHUB_TOKEN`` are only injected when *env_file* is
-    provided (``--env`` on the CLI), so PAT-based auth is opt-in.
+    GitHub auth defaults to SSO via the ``~/.config/gh`` bind mount. To use a
+    PAT instead, put ``GH_TOKEN`` in ``.env`` and pass ``--env``.
 
     When *bedrock* is True, ``CLAUDE_CODE_USE_BEDROCK=1`` is injected and
     *bedrock_profile* (if set) overrides ``AWS_PROFILE`` so the LLM provider
@@ -427,12 +434,6 @@ def build_dev_environment(
         "PI_STUDIO_HOST": "0.0.0.0",  # nosec B104
     }
 
-    if env_file is not None:
-        gh_token = _resolve("GH_TOKEN")
-        if gh_token:
-            env["GH_TOKEN"] = gh_token
-            env["GITHUB_TOKEN"] = gh_token
-
     # Mirror AWS_REGION to AWS_DEFAULT_REGION so both Node.js SDK paths resolve
     env["AWS_DEFAULT_REGION"] = env["AWS_REGION"]
 
@@ -457,7 +458,10 @@ def build_dev_environment(
         key_var = f"OPENAI_API_KEY_{suffix}"
         api_key = dotenv.get(key_var)
         if not api_key:
-            raise ValueError(f"OpenAI profile '{openai_profile}' requires {key_var} in .env")
+            raise ValueError(
+                f"OpenAI profile '{openai_profile}' requires {key_var} in "
+                "~/.augint/.env, or pass --env to load it from ./.env"
+            )
         env["OPENAI_API_KEY"] = api_key
         org_var = f"OPENAI_ORG_ID_{suffix}"
         org_id = dotenv.get(org_var)
@@ -471,6 +475,12 @@ def build_dev_environment(
         val = _resolve(var)
         if val:
             env[var] = val
+
+    # Pass through every var loaded from .env, except keys already populated
+    # above (which preserves CLI-flag wins for AWS_PROFILE etc.).
+    for key, value in dotenv.items():
+        if value is not None and value != "" and key not in env:
+            env[key] = value
 
     if extra_env:
         env.update(extra_env)

--- a/src/ai_shell/templates/augint-env.example
+++ b/src/ai_shell/templates/augint-env.example
@@ -1,7 +1,13 @@
 # ~/.augint/.env — Shared config for the augint tool suite
 # Copy to ~/.augint/.env and uncomment values to set.
-# Project ./.env overrides these. CLI flags override everything.
-# Priority: CLI > ./.env > ~/.augint/.env > os.environ > defaults
+#
+# This file ALWAYS loads. Project ./.env only loads when the user passes
+# --env on the CLI; when loaded, every variable in it flows through to the
+# container.
+#
+# Priority (high → low):
+#   CLI flag > extra_env (.ai-shell.yaml) > ./.env (only with --env) >
+#   ~/.augint/.env (always) > os.environ (allowlisted) > defaults
 #
 # Only world-facts and user-preferences go here (things that exist
 # independently of any single tool). Tool-internal behavior goes in

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -241,7 +241,8 @@ class TestBuildDevEnvironment:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(env_file=env_file)
         assert env["GH_TOKEN"] == "test-token"
-        assert env["GITHUB_TOKEN"] == "test-token"
+        # GITHUB_TOKEN is no longer auto-mirrored — put it in .env explicitly.
+        assert "GITHUB_TOKEN" not in env
 
     def test_passes_through_aws_profile(self):
         with patch.dict("os.environ", {"AWS_PROFILE": "my-sso-profile"}):
@@ -271,7 +272,7 @@ class TestBuildDevEnvironmentDotenv:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
         assert env["GH_TOKEN"] == "from-dotenv"
-        assert env["GITHUB_TOKEN"] == "from-dotenv"
+        assert "GITHUB_TOKEN" not in env
 
     def test_dotenv_overrides_os_environ_with_env_flag(self, tmp_path):
         env_file = tmp_path / ".env"
@@ -281,10 +282,12 @@ class TestBuildDevEnvironmentDotenv:
         assert env["GH_TOKEN"] == "from-dotenv"
 
     def test_extra_env_overrides_dotenv(self, tmp_path):
-        (tmp_path / ".env").write_text("GH_TOKEN=from-dotenv\n")
+        env_file = tmp_path / ".env"
+        env_file.write_text("GH_TOKEN=from-dotenv\n")
         env = build_dev_environment(
             extra_env={"GH_TOKEN": "from-config"},
             project_dir=tmp_path,
+            env_file=env_file,
         )
         assert env["GH_TOKEN"] == "from-config"
 
@@ -301,10 +304,41 @@ class TestBuildDevEnvironmentDotenv:
         assert env["AWS_REGION"] == "us-east-1"
 
     def test_dotenv_aws_region(self, tmp_path):
-        (tmp_path / ".env").write_text("AWS_REGION=eu-west-1\n")
+        env_file = tmp_path / ".env"
+        env_file.write_text("AWS_REGION=eu-west-1\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
+        assert env["AWS_REGION"] == "eu-west-1"
+
+    def test_arbitrary_dotenv_var_passes_through_with_env_flag(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("PI_STUDIO_PORT=8888\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
+        assert env["PI_STUDIO_PORT"] == "8888"
+
+    def test_arbitrary_dotenv_var_blocked_without_env_flag(self, tmp_path):
+        (tmp_path / ".env").write_text("PI_STUDIO_PORT=8888\n")
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path)
-        assert env["AWS_REGION"] == "eu-west-1"
+        assert "PI_STUDIO_PORT" not in env
+
+    def test_global_augint_env_always_loaded(self, isolate_home):
+        global_env = isolate_home / ".augint" / ".env"
+        global_env.parent.mkdir(parents=True, exist_ok=True)
+        global_env.write_text("MY_GLOBAL_VAR=hello\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment()
+        assert env["MY_GLOBAL_VAR"] == "hello"
+
+    def test_cli_flag_beats_dotenv(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("AWS_PROFILE=from-env\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=env_file, aws_profile="cli-wins"
+            )
+        assert env["AWS_PROFILE"] == "cli-wins"
 
 
 class TestBuildDevEnvironmentBedrock:
@@ -400,37 +434,52 @@ class TestBuildDevEnvironmentOpenAIProfile:
     def test_openai_profile_sets_api_key(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_AILLC=sk-test-123\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="aillc"
+            )
         assert env["OPENAI_API_KEY"] == "sk-test-123"
 
     def test_openai_profile_sets_org_id_when_present(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_AILLC=sk-test-123\nOPENAI_ORG_ID_AILLC=org-abc\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="aillc"
+            )
         assert env["OPENAI_API_KEY"] == "sk-test-123"
         assert env["OPENAI_ORG_ID"] == "org-abc"
 
     def test_openai_profile_no_org_id(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_PERSONAL=sk-personal\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="personal")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="personal"
+            )
         assert env["OPENAI_API_KEY"] == "sk-personal"
         assert "OPENAI_ORG_ID" not in env
 
     def test_openai_profile_uppercases_name(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_MYACCT=sk-myacct\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="myacct")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="myacct"
+            )
         assert env["OPENAI_API_KEY"] == "sk-myacct"
 
     def test_openai_profile_missing_key_raises(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_OTHER=sk-other\n")
         with pytest.raises(ValueError, match="OPENAI_API_KEY_AILLC"):
-            build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+            build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="aillc"
+            )
 
     def test_openai_profile_empty_string_is_noop(self):
-        env = build_dev_environment(openai_profile="")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(openai_profile="")
         assert "OPENAI_API_KEY" not in env
         assert "OPENAI_ORG_ID" not in env
 
@@ -485,7 +534,7 @@ class TestBuildDevEnvironmentGhToken:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
         assert env["GH_TOKEN"] == "ghp_from_dotenv"
-        assert env["GITHUB_TOKEN"] == "ghp_from_dotenv"
+        assert "GITHUB_TOKEN" not in env
 
     def test_os_environ_gh_token_not_used_without_env_file(self):
         with patch.dict("os.environ", {"GH_TOKEN": "ghp_from_env"}):
@@ -521,7 +570,22 @@ class TestBuildDevEnvironmentLayeredDotenv:
             env = build_dev_environment()
         assert env["AWS_REGION"] == "from-global"
 
-    def test_project_env_overrides_global(self, tmp_path):
+    def test_project_env_overrides_global_with_env_flag(self, tmp_path):
+        augint_dir = tmp_path / ".augint"
+        augint_dir.mkdir()
+        (augint_dir / ".env").write_text("AWS_REGION=from-global\n")
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        project_env = project_dir / ".env"
+        project_env.write_text("AWS_REGION=from-project\n")
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            env = build_dev_environment(project_dir=project_dir, env_file=project_env)
+        assert env["AWS_REGION"] == "from-project"
+
+    def test_project_env_ignored_without_env_flag(self, tmp_path):
         augint_dir = tmp_path / ".augint"
         augint_dir.mkdir()
         (augint_dir / ".env").write_text("AWS_REGION=from-global\n")
@@ -533,7 +597,7 @@ class TestBuildDevEnvironmentLayeredDotenv:
             patch.dict("os.environ", {}, clear=True),
         ):
             env = build_dev_environment(project_dir=project_dir)
-        assert env["AWS_REGION"] == "from-project"
+        assert env["AWS_REGION"] == "from-global"
 
     def test_dotenv_overrides_os_environ(self, tmp_path):
         augint_dir = tmp_path / ".augint"


### PR DESCRIPTION
## Summary
- `--env` flag now passes every variable in `.env` to the container, not just `GH_TOKEN`. Fixes the bug where `PI_STUDIO_PORT=8888` in `./.env` was ignored by `ai-shell pi`.
- `~/.augint/.env` always loads; `./.env` only loads when `--env` is given.
- Removed `GH_TOKEN`→`GITHUB_TOKEN` auto-mirror — no specials.

## Test plan
- [x] `uv run pytest` (554 pass)
- [x] `uv run ruff check && uv run mypy src/`
- [x] coverage 80.37%
- [ ] manual: `echo PI_STUDIO_PORT=8888 >> .env && ai-shell pi --env` confirms var lands in container