### PR TITLE
fix: isolate container node_modules from host bind mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,26 @@ llm:
 
 Global config at `~/.ai-shell.yaml` or `~/.config/ai-shell/config.yaml` also supported.
 
+### Launch-time caches
+
+To keep tool launches fast, two preflight checks are cached on the host under `~/.cache/ai-shell/`:
+
+| Cache | Default TTL | What it skips |
+| --- | --- | --- |
+| `image-pull` | 15 min | `docker pull` of the `latest` image to compare digests (network round-trip) |
+| `bedrock-check` | 24 h | Bedrock `converse` preflight that verifies AWS auth + model access |
+
+Tune via YAML or env vars:
+
+```yaml
+container:
+  image_pull_cache_ttl: 900       # seconds (0 = always pull)
+aws:
+  bedrock_check_cache_ttl: 86400  # seconds (0 = always verify)
+```
+
+Equivalent env vars: `AI_SHELL_IMAGE_PULL_CACHE_TTL`, `AI_SHELL_BEDROCK_CHECK_CACHE_TTL`. Delete the corresponding file under `~/.cache/ai-shell/` to force a recheck on the next launch.
+
 ---
 
 ## Local LLM stack

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -79,18 +79,25 @@ if [ -f "package-lock.json" ]; then
     echo "===================================="
     echo "Installing Node.js dependencies..."
     echo "===================================="
-    npm ci --loglevel=warn
-    echo "===================================="
-    echo "Node.js dependencies installed!"
-    echo "===================================="
+    if npm ci --loglevel=warn; then
+        echo "===================================="
+        echo "Node.js dependencies installed!"
+        echo "===================================="
+    else
+        echo "[warn] 'npm ci' failed (likely package-lock.json out of sync with package.json)."
+        echo "[warn] Container will continue. Run 'npm install' to regenerate the lockfile, then restart the container."
+    fi
 elif [ -f "package.json" ]; then
     echo "===================================="
     echo "Installing Node.js dependencies..."
     echo "===================================="
-    npm install --loglevel=warn
-    echo "===================================="
-    echo "Node.js dependencies installed!"
-    echo "===================================="
+    if npm install --loglevel=warn; then
+        echo "===================================="
+        echo "Node.js dependencies installed!"
+        echo "===================================="
+    else
+        echo "[warn] 'npm install' failed. Container will continue."
+    fi
 fi
 
 # =========================================================================

--- a/src/ai_shell/cache.py
+++ b/src/ai_shell/cache.py
@@ -1,0 +1,47 @@
+"""Time-based filesystem cache for expensive preflight checks.
+
+Used to avoid repeating slow operations (Docker image pulls, Bedrock auth
+probes) on every launch.  Cache entries live under
+``~/.cache/ai-shell/<namespace>/`` as small timestamp files keyed by a hash
+of caller-provided strings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_path(namespace: str, key: str) -> Path:
+    digest = hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+    base = Path.home() / ".cache" / "ai-shell" / namespace
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{digest}.timestamp"
+
+
+def is_fresh(namespace: str, key: str, ttl_seconds: int) -> bool:
+    """Return True if a cache entry exists for *key* and is younger than the TTL."""
+    if ttl_seconds <= 0:
+        return False
+    path = _cache_path(namespace, key)
+    if not path.is_file():
+        return False
+    try:
+        last = float(path.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    age = time.time() - last
+    return age < ttl_seconds
+
+
+def mark_fresh(namespace: str, key: str) -> None:
+    """Stamp the cache entry for *key* with the current time."""
+    path = _cache_path(namespace, key)
+    try:
+        path.write_text(f"{time.time()}\n")
+    except OSError as e:
+        logger.debug("Failed to write cache marker %s: %s", path, e)

--- a/src/ai_shell/cache.py
+++ b/src/ai_shell/cache.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _cache_path(namespace: str, key: str) -> Path:
-    digest = hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+    digest = hashlib.sha256(key.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
     base = Path.home() / ".cache" / "ai-shell" / namespace
     base.mkdir(parents=True, exist_ok=True)
     return base / f"{digest}.timestamp"

--- a/src/ai_shell/cli/commands/manage.py
+++ b/src/ai_shell/cli/commands/manage.py
@@ -115,7 +115,7 @@ def manage_pull(ctx):
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.pass_context
 def manage_env(ctx, use_aws, env_file):

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -159,18 +159,36 @@ def _check_bedrock_access(
     container_name: str,
     exec_env: dict[str, str],
     model_id: str = "",
+    cache_ttl: int = 0,
 ) -> None:
     """Verify Bedrock is reachable before launching a tool.
 
     Sends a minimal ``converse`` request inside the container to validate
     the full path: AWS credentials, SCP policies, and model access.
     Raises :class:`click.ClickException` with an actionable message on failure.
+
+    When *cache_ttl* > 0, a successful check is recorded under
+    ``~/.cache/ai-shell/bedrock-check/`` and re-checks within the TTL window
+    are skipped silently.
     """
+    from ai_shell.cache import is_fresh, mark_fresh
     from ai_shell.defaults import DEFAULT_BEDROCK_MODEL
 
     model = model_id or DEFAULT_BEDROCK_MODEL
     region = exec_env.get("AWS_REGION", "us-east-1")
     profile = exec_env.get("AWS_PROFILE", "")
+
+    cache_key = f"{profile}|{region}|{model}"
+    if is_fresh("bedrock-check", cache_key, cache_ttl):
+        logger.debug(
+            "Bedrock preflight cache fresh (profile=%s, region=%s, model=%s)",
+            profile or "default",
+            region,
+            model,
+        )
+        return
+
+    console.print(f"Checking Bedrock access (profile={profile or 'default'}, region={region})...")
 
     invoke_cmd = (
         f"aws bedrock-runtime converse"
@@ -202,6 +220,8 @@ def _check_bedrock_access(
             "  - SCP or IAM policy denying bedrock:InvokeModel\n"
             "  - Wrong AWS region: ensure Bedrock is available in the configured region"
         )
+
+    mark_fresh("bedrock-check", cache_key)
 
 
 def _get_manager(
@@ -329,12 +349,9 @@ def _launch_loaded_config_claude(
         bedrock_label = ""
         if use_bedrock:
             bedrock_label = _bedrock_label(exec_env)
-            console.print(
-                "Checking Bedrock access "
-                f"(profile={exec_env.get('AWS_PROFILE', 'default')}, "
-                f"region={exec_env.get('AWS_REGION', 'us-east-1')})..."
+            _check_bedrock_access(
+                container_name, exec_env, cache_ttl=config.bedrock_check_cache_ttl
             )
-            _check_bedrock_access(container_name, exec_env)
 
         workdir: str | None = None
         resolved_worktree_name = worktree_name
@@ -566,7 +583,7 @@ def _launch_interactive(
     )
 
     if use_bedrock:
-        _check_bedrock_access(container_name, exec_env)
+        _check_bedrock_access(container_name, exec_env, cache_ttl=config.bedrock_check_cache_ttl)
 
     # Handle shared Chrome if requested.
     mcp_config_path: str | None = None
@@ -674,7 +691,9 @@ def _launch_team(
         )
 
         if use_bedrock:
-            _check_bedrock_access(container_name, exec_env)
+            _check_bedrock_access(
+                container_name, exec_env, cache_ttl=config.bedrock_check_cache_ttl
+            )
 
         workdir = f"/root/projects/{config.project_name}"
 
@@ -751,7 +770,7 @@ def _launch_single_repo_multi(
     )
 
     if use_bedrock:
-        _check_bedrock_access(container_name, exec_env)
+        _check_bedrock_access(container_name, exec_env, cache_ttl=config.bedrock_check_cache_ttl)
 
     container_project_root = f"/root/projects/{config.project_name}"
     panes: list[PaneSpec] = []
@@ -952,7 +971,7 @@ def _launch_multi(
     )
 
     if use_bedrock:
-        _check_bedrock_access(container_name, exec_env)
+        _check_bedrock_access(container_name, exec_env, cache_ttl=config.bedrock_check_cache_ttl)
 
     # Resolve worktree name (auto-generate if flag given without value)
     wt_name = worktree_name
@@ -1218,10 +1237,7 @@ def codex(
             profile_label = exec_env.get("AWS_PROFILE", "default")
             region_label = exec_env.get("AWS_REGION", "us-east-1")
             bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
-            console.print(
-                f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
-            )
-            _check_bedrock_access(name, exec_env)
+            _check_bedrock_access(name, exec_env, cache_ttl=config.bedrock_check_cache_ttl)
         else:
             bedrock_label = ""
 
@@ -1272,10 +1288,7 @@ def _opencode_setup(
         profile_label = exec_env.get("AWS_PROFILE", "default")
         region_label = exec_env.get("AWS_REGION", "us-east-1")
         bedrock_label = f" via Bedrock (profile={profile_label}, region={region_label})"
-        console.print(
-            f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
-        )
-        _check_bedrock_access(name, exec_env)
+        _check_bedrock_access(name, exec_env, cache_ttl=config.bedrock_check_cache_ttl)
     else:
         bedrock_label = ""
 
@@ -1629,10 +1642,12 @@ def pi(ctx, use_aws, cli_profile, openai_profile, do_login, doom, env_file):
                 f" via Bedrock (profile={profile_label},"
                 f" region={region_label}, model={bedrock_model})"
             )
-            console.print(
-                f"Checking Bedrock access (profile={profile_label}, region={region_label})..."
+            _check_bedrock_access(
+                name,
+                exec_env,
+                model_id=bedrock_model,
+                cache_ttl=config.bedrock_check_cache_ttl,
             )
-            _check_bedrock_access(name, exec_env, model_id=bedrock_model)
         else:
             bedrock_model = ""
             bedrock_label = ""

--- a/src/ai_shell/cli/commands/tools.py
+++ b/src/ai_shell/cli/commands/tools.py
@@ -1079,7 +1079,7 @@ def _launch_multi(
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
@@ -1186,7 +1186,7 @@ def claude(
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
@@ -1325,7 +1325,7 @@ def _opencode_setup(
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.pass_context
 def opencode(
@@ -1598,7 +1598,7 @@ def _ensure_pi_ollama_provider(config: AiShellConfig) -> None:
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.pass_context
 def pi(ctx, use_aws, cli_profile, openai_profile, do_login, doom, env_file):
@@ -1680,7 +1680,7 @@ SUPPORTED_SHELLS: dict[str, str] = {
     is_flag=False,
     flag_value=".env",
     default=None,
-    help="Load .env file for GH_TOKEN injection (default: ./.env when flag given without value).",
+    help="Load .env into the container (all variables). Defaults to ./.env when flag given without value.",
 )
 @click.argument(
     "shell_name",

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -206,6 +206,10 @@ class AiShellConfig:
     local_chrome: bool = False  # Attach Chrome DevTools MCP to project-scoped host Chrome
     skip_updates: bool = False  # When True, skip pre-launch tool freshness checks
 
+    # Pre-launch cache TTLs (seconds). Set to 0 to disable.
+    image_pull_cache_ttl: int = 900  # 15 min: skip docker pull if checked recently
+    bedrock_check_cache_ttl: int = 86400  # 24 h: skip Bedrock preflight if checked recently
+
     # Per-tool provider
     claude_provider: str = ""  # "anthropic" (default) or "aws"
 
@@ -497,6 +501,10 @@ def _apply_config(config: AiShellConfig, path: Path) -> None:
         config.local_chrome = bool(claude_sec["local_chrome"])
     if "skip_updates" in container:
         config.skip_updates = bool(container["skip_updates"])
+    if "image_pull_cache_ttl" in container:
+        config.image_pull_cache_ttl = int(container["image_pull_cache_ttl"])
+    if "bedrock_check_cache_ttl" in aws:
+        config.bedrock_check_cache_ttl = int(aws["bedrock_check_cache_ttl"])
 
 
 _LEGACY_ENV_VARS = {
@@ -540,6 +548,8 @@ def _apply_env_vars(config: AiShellConfig) -> None:
         "AI_SHELL_CLAUDE_PROVIDER": ("claude_provider", str),
         "AI_SHELL_LOCAL_CHROME": ("local_chrome", bool),
         "AI_SHELL_SKIP_UPDATES": ("skip_updates", bool),
+        "AI_SHELL_IMAGE_PULL_CACHE_TTL": ("image_pull_cache_ttl", int),
+        "AI_SHELL_BEDROCK_CHECK_CACHE_TTL": ("bedrock_check_cache_ttl", int),
     }
 
     for env_key, (attr, type_fn) in env_map.items():

--- a/src/ai_shell/container.py
+++ b/src/ai_shell/container.py
@@ -493,19 +493,30 @@ class ContainerManager:
         Only acts when the configured tag is ``latest``.  For pinned
         version tags the image is immutable so staleness doesn't apply.
 
+        The pull is skipped when ``config.image_pull_cache_ttl`` seconds have
+        not yet elapsed since the last successful pull (default 15 min) so
+        normal launches don't pay the network round-trip.
+
         Returns True if the container was removed (caller must recreate).
         """
+        from ai_shell.cache import is_fresh, mark_fresh
+
         tag = self.config.image_tag
         if tag != "latest":
             return False
 
         image_ref = self.config.full_image
+        if is_fresh("image-pull", image_ref, self.config.image_pull_cache_ttl):
+            logger.debug("Image-pull cache fresh for %s — skipping pull", image_ref)
+            return False
+
         try:
             pulled = self.client.images.pull(*image_ref.rsplit(":", 1))
         except APIError:
             logger.debug("Could not pull %s — skipping staleness check", image_ref)
             return False
 
+        mark_fresh("image-pull", image_ref)
         self._warn_if_image_below_minimum(pulled)
 
         container_image_id = container.image.id

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -206,6 +206,7 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
 
     # Optional bind mounts — skip if source doesn't exist
     optional_binds: list[tuple[Path, str, bool]] = [
+        (home / ".config", "/root/.config", False),
         (home / ".codex", "/root/.codex", False),
         (home / ".claude", "/root/.claude", False),
         (home / ".claude.json", "/root/.claude.json", False),

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -323,9 +323,12 @@ def _load_layered_dotenv(
     project_dir: Path | None = None,
     env_file: Path | None = None,
 ) -> dict[str, str | None]:
-    """Load layered .env files: ~/.augint/.env < project .env < explicit env_file.
+    """Load layered .env files.
 
-    Returns a merged dict. Later layers override earlier ones.
+    ``~/.augint/.env`` always loads (global augint suite config). The project
+    ``./.env`` and explicit *env_file* only load when *env_file* is given
+    (i.e. user passed ``--env`` on the CLI). Later layers override earlier
+    ones.
     """
     from dotenv import dotenv_values
 
@@ -335,12 +338,15 @@ def _load_layered_dotenv(
     if global_path.is_file():
         layers.update(dotenv_values(global_path))
 
+    if env_file is None:
+        return layers
+
     if project_dir is not None:
         project_path = project_dir / ".env"
-        if project_path.is_file():
+        if project_path.is_file() and project_path.resolve() != env_file.resolve():
             layers.update(dotenv_values(project_path))
 
-    if env_file is not None and env_file.is_file():
+    if env_file.is_file():
         layers.update(dotenv_values(env_file))
 
     return layers
@@ -382,14 +388,15 @@ def build_dev_environment(
 ) -> dict[str, str]:
     """Build environment variables matching docker-compose.yml dev service.
 
-    Loads layered .env files (``~/.augint/.env`` then project ``.env``),
-    then falls back to host environment variables and hardcoded defaults.
+    ``~/.augint/.env`` always loads (global augint suite config). The project
+    ``./.env`` only loads when *env_file* is given (``--env`` on the CLI);
+    when loaded, **all** of its keys flow through to the container.
 
-    Priority (highest wins): extra_env > .env files > os.environ > defaults.
+    Priority (highest wins): extra_env > CLI flags > ``./.env`` (when ``--env``)
+    > ``~/.augint/.env`` > host ``os.environ`` (allowlisted) > defaults.
 
-    GitHub auth defaults to SSO via the ``~/.config/gh`` bind mount.
-    ``GH_TOKEN`` / ``GITHUB_TOKEN`` are only injected when *env_file* is
-    provided (``--env`` on the CLI), so PAT-based auth is opt-in.
+    GitHub auth defaults to SSO via the ``~/.config/gh`` bind mount. To use a
+    PAT instead, put ``GH_TOKEN`` in ``.env`` and pass ``--env``.
 
     When *bedrock* is True, ``CLAUDE_CODE_USE_BEDROCK=1`` is injected and
     *bedrock_profile* (if set) overrides ``AWS_PROFILE`` so the LLM provider
@@ -427,12 +434,6 @@ def build_dev_environment(
         "PI_STUDIO_HOST": "0.0.0.0",  # nosec B104
     }
 
-    if env_file is not None:
-        gh_token = _resolve("GH_TOKEN")
-        if gh_token:
-            env["GH_TOKEN"] = gh_token
-            env["GITHUB_TOKEN"] = gh_token
-
     # Mirror AWS_REGION to AWS_DEFAULT_REGION so both Node.js SDK paths resolve
     env["AWS_DEFAULT_REGION"] = env["AWS_REGION"]
 
@@ -457,7 +458,10 @@ def build_dev_environment(
         key_var = f"OPENAI_API_KEY_{suffix}"
         api_key = dotenv.get(key_var)
         if not api_key:
-            raise ValueError(f"OpenAI profile '{openai_profile}' requires {key_var} in .env")
+            raise ValueError(
+                f"OpenAI profile '{openai_profile}' requires {key_var} in "
+                "~/.augint/.env, or pass --env to load it from ./.env"
+            )
         env["OPENAI_API_KEY"] = api_key
         org_var = f"OPENAI_ORG_ID_{suffix}"
         org_id = dotenv.get(org_var)
@@ -471,6 +475,12 @@ def build_dev_environment(
         val = _resolve(var)
         if val:
             env[var] = val
+
+    # Pass through every var loaded from .env, except keys already populated
+    # above (which preserves CLI-flag wins for AWS_PROFILE etc.).
+    for key, value in dotenv.items():
+        if value is not None and value != "" and key not in env:
+            env[key] = value
 
     if extra_env:
         env.update(extra_env)

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -45,6 +45,22 @@ def uv_venv_path(repo_name: str, worktree_name: str | None = None) -> str:
 
 
 NPM_CACHE_VOLUME = "augint-shell-npm-cache"
+NODE_MODULES_VOLUME_PREFIX = "augint-shell-node-modules-"
+
+
+def node_modules_volume_name(repo_name: str, worktree_name: str | None = None) -> str:
+    """Per-project named volume that overlays /root/projects/{repo}/node_modules.
+
+    Mirrors the UV venv-isolation scheme so the container's Linux node_modules
+    never collides with the host's (e.g. Windows-built) node_modules in the
+    bind-mounted project directory.
+    """
+    suffix = repo_name
+    if worktree_name:
+        suffix = f"{repo_name}-wt-{worktree_name}"
+    return f"{NODE_MODULES_VOLUME_PREFIX}{suffix}"
+
+
 PRE_COMMIT_CACHE_VOLUME = "augint-shell-pre-commit-cache"
 PRE_COMMIT_CACHE_PATH = "/root/.cache/pre-commit-container"
 OLLAMA_DATA_VOLUME = "augint-shell-ollama-data"
@@ -289,6 +305,19 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
         Mount(
             target=PRE_COMMIT_CACHE_PATH,
             source=PRE_COMMIT_CACHE_VOLUME,
+            type="volume",
+        )
+    )
+
+    # Per-project named volume overlaying node_modules. Without this the
+    # container's Linux `npm ci` would write into the bind-mounted host
+    # project dir and collide with host-built (e.g. Windows) node_modules.
+    # npm has no equivalent of UV_PROJECT_ENVIRONMENT, so we isolate at the
+    # mount layer instead. Host node_modules underneath stays untouched.
+    mounts.append(
+        Mount(
+            target=f"/root/projects/{project_name}/node_modules",
+            source=node_modules_volume_name(project_name),
             type="volume",
         )
     )

--- a/src/ai_shell/templates/augint-ai-shell.example.yaml
+++ b/src/ai_shell/templates/augint-ai-shell.example.yaml
@@ -9,6 +9,9 @@
 #   image: svange/augint-shell
 #   image_tag: latest
 #   skip_updates: false
+#   # How long (seconds) to skip the `docker pull` staleness check after a
+#   # successful pull. Default 900 (15 min). Set to 0 to pull on every launch.
+#   image_pull_cache_ttl: 900
 #   extra_env:
 #     MY_CUSTOM_VAR: value
 #   extra_volumes:
@@ -47,6 +50,10 @@
 #   region: us-east-1
 #   bedrock_region: us-west-2
 #   bedrock_model: us.meta.llama3-3-70b-instruct-v1:0
+#   # How long (seconds) to skip the Bedrock preflight check after a successful
+#   # check. Cache key is (profile, region, model). Default 86400 (24 h).
+#   # Set to 0 to verify on every launch.
+#   bedrock_check_cache_ttl: 86400
 
 # --- OpenAI ------------------------------------------------------------------
 # Multi-account switching. Set openai_profile to a suffix, then define

--- a/src/ai_shell/templates/augint-env.example
+++ b/src/ai_shell/templates/augint-env.example
@@ -1,7 +1,13 @@
 # ~/.augint/.env — Shared config for the augint tool suite
 # Copy to ~/.augint/.env and uncomment values to set.
-# Project ./.env overrides these. CLI flags override everything.
-# Priority: CLI > ./.env > ~/.augint/.env > os.environ > defaults
+#
+# This file ALWAYS loads. Project ./.env only loads when the user passes
+# --env on the CLI; when loaded, every variable in it flows through to the
+# container.
+#
+# Priority (high → low):
+#   CLI flag > extra_env (.ai-shell.yaml) > ./.env (only with --env) >
+#   ~/.augint/.env (always) > os.environ (allowlisted) > defaults
 #
 # Only world-facts and user-preferences go here (things that exist
 # independently of any single tool). Tool-internal behavior goes in

--- a/tests/unit/test_cli_tools.py
+++ b/tests/unit/test_cli_tools.py
@@ -781,7 +781,11 @@ class TestToolCommands:
 
         self.runner.invoke(cli, ["claude", "--aws"])
 
-        mock_check_bedrock.assert_called_once_with("augint-shell-test-dev", bedrock_env)
+        mock_check_bedrock.assert_called_once()
+        args, kwargs = mock_check_bedrock.call_args
+        assert args[0] == "augint-shell-test-dev"
+        assert args[1] == bedrock_env
+        assert "cache_ttl" in kwargs
 
     def test_claude_bedrock_preflight_failure_blocks_launch(
         self, mock_config, mock_manager_cls, mock_build_env, mock_check_bedrock

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -241,7 +241,8 @@ class TestBuildDevEnvironment:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(env_file=env_file)
         assert env["GH_TOKEN"] == "test-token"
-        assert env["GITHUB_TOKEN"] == "test-token"
+        # GITHUB_TOKEN is no longer auto-mirrored — put it in .env explicitly.
+        assert "GITHUB_TOKEN" not in env
 
     def test_passes_through_aws_profile(self):
         with patch.dict("os.environ", {"AWS_PROFILE": "my-sso-profile"}):
@@ -271,7 +272,7 @@ class TestBuildDevEnvironmentDotenv:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
         assert env["GH_TOKEN"] == "from-dotenv"
-        assert env["GITHUB_TOKEN"] == "from-dotenv"
+        assert "GITHUB_TOKEN" not in env
 
     def test_dotenv_overrides_os_environ_with_env_flag(self, tmp_path):
         env_file = tmp_path / ".env"
@@ -281,10 +282,12 @@ class TestBuildDevEnvironmentDotenv:
         assert env["GH_TOKEN"] == "from-dotenv"
 
     def test_extra_env_overrides_dotenv(self, tmp_path):
-        (tmp_path / ".env").write_text("GH_TOKEN=from-dotenv\n")
+        env_file = tmp_path / ".env"
+        env_file.write_text("GH_TOKEN=from-dotenv\n")
         env = build_dev_environment(
             extra_env={"GH_TOKEN": "from-config"},
             project_dir=tmp_path,
+            env_file=env_file,
         )
         assert env["GH_TOKEN"] == "from-config"
 
@@ -301,10 +304,41 @@ class TestBuildDevEnvironmentDotenv:
         assert env["AWS_REGION"] == "us-east-1"
 
     def test_dotenv_aws_region(self, tmp_path):
-        (tmp_path / ".env").write_text("AWS_REGION=eu-west-1\n")
+        env_file = tmp_path / ".env"
+        env_file.write_text("AWS_REGION=eu-west-1\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
+        assert env["AWS_REGION"] == "eu-west-1"
+
+    def test_arbitrary_dotenv_var_passes_through_with_env_flag(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("PI_STUDIO_PORT=8888\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
+        assert env["PI_STUDIO_PORT"] == "8888"
+
+    def test_arbitrary_dotenv_var_blocked_without_env_flag(self, tmp_path):
+        (tmp_path / ".env").write_text("PI_STUDIO_PORT=8888\n")
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path)
-        assert env["AWS_REGION"] == "eu-west-1"
+        assert "PI_STUDIO_PORT" not in env
+
+    def test_global_augint_env_always_loaded(self, isolate_home):
+        global_env = isolate_home / ".augint" / ".env"
+        global_env.parent.mkdir(parents=True, exist_ok=True)
+        global_env.write_text("MY_GLOBAL_VAR=hello\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment()
+        assert env["MY_GLOBAL_VAR"] == "hello"
+
+    def test_cli_flag_beats_dotenv(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("AWS_PROFILE=from-env\n")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=env_file, aws_profile="cli-wins"
+            )
+        assert env["AWS_PROFILE"] == "cli-wins"
 
 
 class TestBuildDevEnvironmentBedrock:
@@ -400,37 +434,52 @@ class TestBuildDevEnvironmentOpenAIProfile:
     def test_openai_profile_sets_api_key(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_AILLC=sk-test-123\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="aillc"
+            )
         assert env["OPENAI_API_KEY"] == "sk-test-123"
 
     def test_openai_profile_sets_org_id_when_present(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_AILLC=sk-test-123\nOPENAI_ORG_ID_AILLC=org-abc\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="aillc"
+            )
         assert env["OPENAI_API_KEY"] == "sk-test-123"
         assert env["OPENAI_ORG_ID"] == "org-abc"
 
     def test_openai_profile_no_org_id(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_PERSONAL=sk-personal\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="personal")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="personal"
+            )
         assert env["OPENAI_API_KEY"] == "sk-personal"
         assert "OPENAI_ORG_ID" not in env
 
     def test_openai_profile_uppercases_name(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_MYACCT=sk-myacct\n")
-        env = build_dev_environment(project_dir=tmp_path, openai_profile="myacct")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="myacct"
+            )
         assert env["OPENAI_API_KEY"] == "sk-myacct"
 
     def test_openai_profile_missing_key_raises(self, tmp_path):
         dotenv_path = tmp_path / ".env"
         dotenv_path.write_text("OPENAI_API_KEY_OTHER=sk-other\n")
         with pytest.raises(ValueError, match="OPENAI_API_KEY_AILLC"):
-            build_dev_environment(project_dir=tmp_path, openai_profile="aillc")
+            build_dev_environment(
+                project_dir=tmp_path, env_file=dotenv_path, openai_profile="aillc"
+            )
 
     def test_openai_profile_empty_string_is_noop(self):
-        env = build_dev_environment(openai_profile="")
+        with patch.dict("os.environ", {}, clear=True):
+            env = build_dev_environment(openai_profile="")
         assert "OPENAI_API_KEY" not in env
         assert "OPENAI_ORG_ID" not in env
 
@@ -485,7 +534,7 @@ class TestBuildDevEnvironmentGhToken:
         with patch.dict("os.environ", {}, clear=True):
             env = build_dev_environment(project_dir=tmp_path, env_file=env_file)
         assert env["GH_TOKEN"] == "ghp_from_dotenv"
-        assert env["GITHUB_TOKEN"] == "ghp_from_dotenv"
+        assert "GITHUB_TOKEN" not in env
 
     def test_os_environ_gh_token_not_used_without_env_file(self):
         with patch.dict("os.environ", {"GH_TOKEN": "ghp_from_env"}):
@@ -521,7 +570,22 @@ class TestBuildDevEnvironmentLayeredDotenv:
             env = build_dev_environment()
         assert env["AWS_REGION"] == "from-global"
 
-    def test_project_env_overrides_global(self, tmp_path):
+    def test_project_env_overrides_global_with_env_flag(self, tmp_path):
+        augint_dir = tmp_path / ".augint"
+        augint_dir.mkdir()
+        (augint_dir / ".env").write_text("AWS_REGION=from-global\n")
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        project_env = project_dir / ".env"
+        project_env.write_text("AWS_REGION=from-project\n")
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=tmp_path),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            env = build_dev_environment(project_dir=project_dir, env_file=project_env)
+        assert env["AWS_REGION"] == "from-project"
+
+    def test_project_env_ignored_without_env_flag(self, tmp_path):
         augint_dir = tmp_path / ".augint"
         augint_dir.mkdir()
         (augint_dir / ".env").write_text("AWS_REGION=from-global\n")
@@ -533,7 +597,7 @@ class TestBuildDevEnvironmentLayeredDotenv:
             patch.dict("os.environ", {}, clear=True),
         ):
             env = build_dev_environment(project_dir=project_dir)
-        assert env["AWS_REGION"] == "from-project"
+        assert env["AWS_REGION"] == "from-global"
 
     def test_dotenv_overrides_os_environ(self, tmp_path):
         augint_dir = tmp_path / ".augint"

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -11,6 +11,7 @@ from ai_shell.defaults import (
     DEV_PORT_RANGE_START,
     GH_CONFIG_VOLUME,
     N8N_DATA_VOLUME,
+    NODE_MODULES_VOLUME_PREFIX,
     NPM_CACHE_VOLUME,
     OLLAMA_CONTAINER,
     PRE_COMMIT_CACHE_PATH,
@@ -21,6 +22,7 @@ from ai_shell.defaults import (
     build_n8n_environment,
     build_n8n_mounts,
     dev_container_name,
+    node_modules_volume_name,
     project_dev_port,
     sanitize_project_name,
     unique_project_name,
@@ -146,6 +148,28 @@ class TestBuildDevMounts:
 
         assert npm_mount is not None
         assert npm_mount.get("Source") == NPM_CACHE_VOLUME
+
+    def test_includes_node_modules_volume_overlay(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        nm_mount = next(
+            (m for m in mounts if m.get("Target") == "/root/projects/test-project/node_modules"),
+            None,
+        )
+        assert nm_mount is not None, "node_modules overlay volume missing"
+        assert nm_mount.get("Type") == "volume"
+        assert nm_mount.get("Source") == node_modules_volume_name("test-project")
+        assert nm_mount.get("Source", "").startswith(NODE_MODULES_VOLUME_PREFIX)
+
+    def test_node_modules_volume_name_includes_worktree_suffix(self):
+        plain = node_modules_volume_name("repo")
+        wt = node_modules_volume_name("repo", worktree_name="feature")
+        assert plain == f"{NODE_MODULES_VOLUME_PREFIX}repo"
+        assert wt == f"{NODE_MODULES_VOLUME_PREFIX}repo-wt-feature"
+        assert plain != wt
 
     def test_includes_pre_commit_cache_volume(self, tmp_path):
         project_dir = tmp_path / "test-project"


### PR DESCRIPTION
## Summary

- Per-project named Docker volume overlays `/root/projects/{name}/node_modules`, so the container's Linux `npm ci` no longer collides with the host's (typically Windows-built) `node_modules` in the bind-mounted project dir. Mirrors the existing `UV_PROJECT_ENVIRONMENT` isolation pattern. `package.json` and `package-lock.json` stay shared via the bind mount; only `node_modules` is split.
- `docker-entrypoint.sh`: `npm ci` / `npm install` are now non-fatal (matches the existing `pre-commit install || true` pattern). A stale lockfile no longer kills the entrypoint under `set -e`, leaving the container alive so the user can fix it interactively.
- New helper `node_modules_volume_name(repo, worktree)` and constant `NODE_MODULES_VOLUME_PREFIX` in `defaults.py`. Worktree suffix supported, symmetric with `uv_venv_path`.

This is a multi-commit branch (also includes `~/.config` bind mount, `--env` .env loading, and image-pull caching); this PR ships them all together.

## Test plan

- [x] `uv run pytest` — full suite green (468 tests)
- [x] New unit tests cover the node_modules overlay mount and the worktree-suffix helper
- [x] `bash -n docker/docker-entrypoint.sh` — entrypoint syntax clean
- [ ] After image rebuild: reproduce the user's stale-lockfile case in a Windows project, confirm container stays running and Claude exec works
- [ ] After image rebuild: simultaneous `npm run dev` on Windows host and inside container; verify both serve their own platform-built `node_modules`