### PR TITLE
feat(monorepo): isolate per-workspace node_modules via globs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,6 +110,10 @@ RUN curl -fsSL https://bun.sh/install | bash && \
     ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
     ln -s /root/.bun/bin/bunx /usr/local/bin/bunx
 
+# Enable corepack so pnpm and yarn shims are on PATH for monorepos that
+# declare them via package.json "packageManager". Ships with Node.js LTS.
+RUN corepack enable
+
 # Install AWS CDK CLI
 RUN npm install -g aws-cdk
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -75,29 +75,32 @@ if [ -f ".pre-commit-config.yaml" ] && [ -d ".git" ]; then
     echo "===================================="
 fi
 
-if [ -f "package-lock.json" ]; then
+if [ -f "package.json" ]; then
+    if [ -f "pnpm-lock.yaml" ]; then
+        _pm="pnpm"
+        _cmd="pnpm install --loglevel=warn"
+    elif [ -f "yarn.lock" ]; then
+        _pm="yarn"
+        _cmd="yarn install --silent"
+    elif [ -f "package-lock.json" ]; then
+        _pm="npm"
+        _cmd="npm ci --loglevel=warn"
+    else
+        _pm="npm"
+        _cmd="npm install --loglevel=warn"
+    fi
     echo "===================================="
-    echo "Installing Node.js dependencies..."
+    echo "Installing Node.js dependencies (${_pm})..."
     echo "===================================="
-    if npm ci --loglevel=warn; then
+    if $_cmd; then
         echo "===================================="
         echo "Node.js dependencies installed!"
         echo "===================================="
     else
-        echo "[warn] 'npm ci' failed (likely package-lock.json out of sync with package.json)."
-        echo "[warn] Container will continue. Run 'npm install' to regenerate the lockfile, then restart the container."
+        echo "[warn] '${_cmd}' failed. Container will continue."
+        echo "[warn] For npm: lockfile may be out of sync; run 'npm install' to regenerate."
     fi
-elif [ -f "package.json" ]; then
-    echo "===================================="
-    echo "Installing Node.js dependencies..."
-    echo "===================================="
-    if npm install --loglevel=warn; then
-        echo "===================================="
-        echo "Node.js dependencies installed!"
-        echo "===================================="
-    else
-        echo "[warn] 'npm install' failed. Container will continue."
-    fi
+    unset _pm _cmd
 fi
 
 # =========================================================================

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -191,6 +191,9 @@ class AiShellConfig:
     extra_env: dict[str, str] = field(default_factory=dict)
     extra_volumes: list[str] = field(default_factory=list)
     extra_ports: list[int] = field(default_factory=list)
+    # Glob patterns (relative to project_dir) for monorepo workspace
+    # node_modules directories. Each match gets an isolated named volume.
+    node_modules_paths: list[str] = field(default_factory=list)
 
     # AWS
     ai_profile: str = ""  # AWS profile for infra (sets AWS_PROFILE in container)
@@ -438,6 +441,8 @@ def _apply_config(config: AiShellConfig, path: Path) -> None:
         config.extra_volumes.extend(container["extra_volumes"])
     if "ports" in container:
         config.extra_ports.extend(int(p) for p in container["ports"])
+    if "node_modules_paths" in container:
+        config.node_modules_paths.extend(str(p) for p in container["node_modules_paths"])
 
     # [llm] section
     llm = data.get("llm", {})

--- a/src/ai_shell/container.py
+++ b/src/ai_shell/container.py
@@ -271,7 +271,11 @@ class ContainerManager:
 
     def _create_dev_container(self, name: str) -> Container:
         """Create the dev container with all docker-compose config."""
-        mounts = build_dev_mounts(self.config.project_dir, self.config.project_name)
+        mounts = build_dev_mounts(
+            self.config.project_dir,
+            self.config.project_name,
+            extra_node_modules_paths=self.config.node_modules_paths,
+        )
         environment = build_dev_environment(
             self.config.extra_env,
             self.config.project_dir,

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -48,16 +48,25 @@ NPM_CACHE_VOLUME = "augint-shell-npm-cache"
 NODE_MODULES_VOLUME_PREFIX = "augint-shell-node-modules-"
 
 
-def node_modules_volume_name(repo_name: str, worktree_name: str | None = None) -> str:
-    """Per-project named volume that overlays /root/projects/{repo}/node_modules.
+def node_modules_volume_name(
+    repo_name: str,
+    worktree_name: str | None = None,
+    subpath: str | None = None,
+) -> str:
+    """Per-project named volume that overlays a node_modules directory.
 
     Mirrors the UV venv-isolation scheme so the container's Linux node_modules
     never collides with the host's (e.g. Windows-built) node_modules in the
     bind-mounted project directory.
+
+    When *subpath* is given (e.g. ``"apps/web"``), a sanitized slug is appended
+    so monorepos can isolate each workspace's node_modules independently.
     """
     suffix = repo_name
     if worktree_name:
         suffix = f"{repo_name}-wt-{worktree_name}"
+    if subpath:
+        suffix = f"{suffix}-{_sanitize_name(subpath.lower())}"
     return f"{NODE_MODULES_VOLUME_PREFIX}{suffix}"
 
 
@@ -193,11 +202,21 @@ def project_dev_port(
     return DEV_PORT_RANGE_START + (int(digest[:8], 16) % DEV_PORT_RANGE_SIZE)
 
 
-def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
+def build_dev_mounts(
+    project_dir: Path,
+    project_name: str,
+    extra_node_modules_paths: list[str] | None = None,
+) -> list[Mount]:
     """Build the full mount list matching docker-compose.yml dev service.
 
     Required mounts are always included. Optional mounts are skipped
     if the source path doesn't exist on the host.
+
+    *extra_node_modules_paths* is a list of glob patterns relative to
+    *project_dir*. Each glob match (that is a directory) gets its own named
+    volume overlaid at ``{match}/node_modules`` inside the container, so each
+    workspace in a monorepo isolates its Linux node_modules from the host
+    bind mount the same way the root overlay does.
     """
     from docker.types import Mount
 
@@ -322,6 +341,32 @@ def build_dev_mounts(project_dir: Path, project_name: str) -> list[Mount]:
             type="volume",
         )
     )
+
+    # Monorepo workspaces: overlay an isolated named volume on each matched
+    # workspace's node_modules so per-app installs (npm/pnpm/yarn workspaces)
+    # land in container-only storage rather than the host bind mount.
+    project_root = project_dir.resolve()
+    seen_targets: set[str] = {f"/root/projects/{project_name}/node_modules"}
+    for pattern in extra_node_modules_paths or []:
+        for match in sorted(project_root.glob(pattern)):
+            if not match.is_dir():
+                continue
+            try:
+                rel = match.relative_to(project_root)
+            except ValueError:
+                continue
+            rel_posix = rel.as_posix()
+            target = f"/root/projects/{project_name}/{rel_posix}/node_modules"
+            if target in seen_targets:
+                continue
+            seen_targets.add(target)
+            mounts.append(
+                Mount(
+                    target=target,
+                    source=node_modules_volume_name(project_name, subpath=rel_posix),
+                    type="volume",
+                )
+            )
 
     return mounts
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -252,6 +252,13 @@ extra_env = { FOO = "bar", BAZ = "qux" }
         config = load_config(project_dir=tmp_path)
         assert config.extra_env == {"FOO": "bar", "BAZ": "qux"}
 
+    def test_node_modules_paths_from_yaml(self, tmp_path):
+        (tmp_path / ".ai-shell.yaml").write_text(
+            "container:\n  node_modules_paths:\n    - apps/*\n    - packages/*\n"
+        )
+        config = load_config(project_dir=tmp_path)
+        assert config.node_modules_paths == ["apps/*", "packages/*"]
+
     def test_dev_ports_defaults(self):
         config = AiShellConfig()
         assert config.dev_ports == sorted(DEFAULT_DEV_PORTS)

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -171,6 +171,74 @@ class TestBuildDevMounts:
         assert wt == f"{NODE_MODULES_VOLUME_PREFIX}repo-wt-feature"
         assert plain != wt
 
+    def test_node_modules_volume_name_with_subpath(self):
+        v = node_modules_volume_name("repo", subpath="apps/web")
+        assert v == f"{NODE_MODULES_VOLUME_PREFIX}repo-apps-web"
+
+    def test_node_modules_volume_name_with_worktree_and_subpath(self):
+        v = node_modules_volume_name("repo", worktree_name="feature", subpath="apps/web")
+        assert v == f"{NODE_MODULES_VOLUME_PREFIX}repo-wt-feature-apps-web"
+
+    def test_build_dev_mounts_expands_node_modules_globs(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        (project_dir / "apps" / "web").mkdir(parents=True)
+        (project_dir / "apps" / "api").mkdir(parents=True)
+
+        mounts = build_dev_mounts(project_dir, "test-project", extra_node_modules_paths=["apps/*"])
+
+        targets_by_target = {m.get("Target"): m for m in mounts}
+        web_target = "/root/projects/test-project/apps/web/node_modules"
+        api_target = "/root/projects/test-project/apps/api/node_modules"
+        assert web_target in targets_by_target
+        assert api_target in targets_by_target
+        assert targets_by_target[web_target].get("Type") == "volume"
+        assert targets_by_target[web_target].get("Source") == node_modules_volume_name(
+            "test-project", subpath="apps/web"
+        )
+        assert targets_by_target[api_target].get("Source") == node_modules_volume_name(
+            "test-project", subpath="apps/api"
+        )
+
+    def test_build_dev_mounts_skips_nonexistent_glob_matches(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(
+            project_dir, "test-project", extra_node_modules_paths=["apps/*", "packages/*"]
+        )
+
+        extra = [
+            m
+            for m in mounts
+            if str(m.get("Target", "")).startswith("/root/projects/test-project/apps/")
+            or str(m.get("Target", "")).startswith("/root/projects/test-project/packages/")
+        ]
+        assert extra == []
+
+    def test_build_dev_mounts_skips_non_directory_matches(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        (project_dir / "apps").mkdir(parents=True)
+        (project_dir / "apps" / "README.md").write_text("not a workspace")
+
+        mounts = build_dev_mounts(project_dir, "test-project", extra_node_modules_paths=["apps/*"])
+
+        for m in mounts:
+            assert m.get("Target") != "/root/projects/test-project/apps/README.md/node_modules"
+
+    def test_build_dev_mounts_deduplicates_overlapping_globs(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        (project_dir / "apps" / "web").mkdir(parents=True)
+
+        mounts = build_dev_mounts(
+            project_dir,
+            "test-project",
+            extra_node_modules_paths=["apps/*", "apps/web"],
+        )
+
+        web_target = "/root/projects/test-project/apps/web/node_modules"
+        web_mounts = [m for m in mounts if m.get("Target") == web_target]
+        assert len(web_mounts) == 1
+
     def test_includes_pre_commit_cache_volume(self, tmp_path):
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()


### PR DESCRIPTION
## Summary
- Add `container.node_modules_paths` (glob list) so monorepos can isolate per-workspace `node_modules` with their own named volumes, mirroring the existing root-level overlay.
- Detect `pnpm-lock.yaml` / `yarn.lock` / `package-lock.json` in the entrypoint and run the matching install command; enable `corepack` in the Dockerfile so pnpm/yarn shims are available.
- Volume naming: `augint-shell-node-modules-{repo}[-wt-{wt}]-{sanitized-subpath}`.

Replaces #126, which was blocked by stale commits already squash-merged to main.

## Test plan
- [x] `uv run pytest` (177 passing in target files; full suite previously green pre-rebase)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/`
- [ ] End-to-end against augint-platform: add `node_modules_paths: ['apps/*', 'packages/*']` to `.ai-shell.yaml`, `ai-shell shell`, confirm pnpm install populates `apps/*/node_modules` inside the container without touching the host bind mount.

## Example config
```yaml
container:
  node_modules_paths:
    - apps/*
    - packages/*
```