### PR TITLE
feat(container): PHP 8.4 toolchain, composer/vendor + pnpm caching, zapier CLI + auth persistence

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,37 @@ RUN curl -fsSL https://bun.sh/install | bash && \
 # declare them via package.json "packageManager". Ships with Node.js LTS.
 RUN corepack enable
 
+# Install PHP 8.4 CLI + extensions (deb.sury.org) for the Laravel dev loop
+# (artisan, Pest, Pint, tinker). 8.4 matches the FrankenPHP 1-php8.4 runtime
+# images Laravel projects deploy on. Extension set mirrors those runtime
+# images (pdo_pgsql pcntl opcache intl bcmath) plus the basics FrankenPHP
+# bundles that Debian packages separately. postgresql-client gives psql
+# parity with the already-shipped sqlite3 for docker-compose Postgres setups.
+RUN curl -fsSL https://packages.sury.org/debsuryorg-archive-keyring.deb -o /tmp/sury-keyring.deb && \
+    dpkg -i /tmp/sury-keyring.deb && \
+    rm /tmp/sury-keyring.deb && \
+    echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ bookworm main" \
+        > /etc/apt/sources.list.d/php.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    php8.4-cli \
+    php8.4-pgsql \
+    php8.4-sqlite3 \
+    php8.4-mbstring \
+    php8.4-xml \
+    php8.4-curl \
+    php8.4-zip \
+    php8.4-intl \
+    php8.4-bcmath \
+    php8.4-readline \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Composer 2 (PHP dependency manager; covers Pint/Pest/artisan deps,
+# no global Laravel installer needed)
+RUN curl -fsSL https://getcomposer.org/installer -o /tmp/composer-setup.php && \
+    php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm /tmp/composer-setup.php
+
 # Install AWS CDK CLI
 RUN npm install -g aws-cdk
 
@@ -156,6 +187,10 @@ RUN npm install -g agent-browser && \
 
 # Install Playwright CLI (advanced browser automation)
 RUN npm install -g @playwright/cli
+
+# Install Zapier Platform CLI (register/validate/push Zapier integrations
+# that live inside project repos). Auth persists via the ~/.zapierrc bind.
+RUN npm install -g zapier-platform-cli
 
 # Build argument for flexible project directory
 ARG PROJECT_DIR=current-project

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -103,6 +103,20 @@ if [ -f "package.json" ]; then
     unset _pm _cmd
 fi
 
+if [ -f "composer.json" ] && command -v composer >/dev/null 2>&1; then
+    echo "===================================="
+    echo "Installing PHP dependencies (composer)..."
+    echo "===================================="
+    # First run also populates the per-project vendor/ overlay volume.
+    if composer install --no-interaction; then
+        echo "===================================="
+        echo "PHP dependencies installed!"
+        echo "===================================="
+    else
+        echo "[warn] 'composer install' failed. Container will continue."
+    fi
+fi
+
 # =========================================================================
 # AUTO-UPDATE: Background cron + initial tool update
 # Remove this block to disable auto-updates.

--- a/docker/update-tools.sh
+++ b/docker/update-tools.sh
@@ -95,8 +95,8 @@ _update_pi() {
 }
 
 _update_npm_tools() {
-    _log "Updating npm tools (aws-cdk, playwright-cli, agent-browser)..."
-    npm install -g aws-cdk@latest @playwright/cli@latest agent-browser@latest 2>&1 || true
+    _log "Updating npm tools (aws-cdk, playwright-cli, agent-browser, zapier)..."
+    npm install -g aws-cdk@latest @playwright/cli@latest agent-browser@latest zapier-platform-cli@latest 2>&1 || true
 }
 
 _update_tool() {

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -72,6 +72,24 @@ def node_modules_volume_name(
     return f"{NODE_MODULES_VOLUME_PREFIX}{suffix}"
 
 
+COMPOSER_CACHE_VOLUME = "augint-shell-composer-cache"
+PNPM_STORE_VOLUME = "augint-shell-pnpm-store"
+VENDOR_VOLUME_PREFIX = "augint-shell-vendor-"
+
+
+def vendor_volume_name(repo_name: str, worktree_name: str | None = None) -> str:
+    """Per-project named volume that overlays composer's ``vendor/`` directory.
+
+    Same rationale as :func:`node_modules_volume_name`: ``vendor/`` on a
+    drvfs/9p bind mount is slow, and overlaying keeps the container's
+    Linux-built vendor tree separate from whatever the host has.
+    """
+    suffix = repo_name
+    if worktree_name:
+        suffix = f"{repo_name}-wt-{worktree_name}"
+    return f"{VENDOR_VOLUME_PREFIX}{suffix}"
+
+
 PRE_COMMIT_CACHE_VOLUME = "augint-shell-pre-commit-cache"
 PRE_COMMIT_CACHE_PATH = "/root/.cache/pre-commit-container"
 OLLAMA_DATA_VOLUME = "augint-shell-ollama-data"
@@ -294,6 +312,13 @@ def build_dev_mounts(
     for d in (".pi", ".augint", ".plannotator"):
         (home / d).mkdir(parents=True, exist_ok=True)
 
+    # Zapier CLI auth is a single JSON file; pre-create it so the bind mount
+    # exists and `zapier login` inside the container persists across
+    # container recreations (mirrors the .claude.json single-file bind).
+    zapierrc = home / ".zapierrc"
+    if not zapierrc.exists():
+        zapierrc.write_text("{}\n")
+
     # Optional bind mounts — skip if source doesn't exist
     optional_binds: list[tuple[Path, str, bool]] = [
         (home / ".config", "/root/.config", False),
@@ -303,6 +328,7 @@ def build_dev_mounts(
         (home / ".pi", "/root/.pi", False),
         (home / ".augint", "/root/.augint", False),
         (home / ".plannotator", "/root/.plannotator", False),
+        (home / ".zapierrc", "/root/.zapierrc", False),
         (home / ".ssh", "/root/.ssh", True),
         (home / ".gitconfig", "/root/.gitconfig.windows", True),
         (home / ".aws", "/root/.aws", False),
@@ -373,6 +399,27 @@ def build_dev_mounts(
         )
     )
 
+    # Named volume: composer cache (shared across all projects). Without it
+    # composer re-downloads every package on container recreation.
+    mounts.append(
+        Mount(
+            target="/root/.cache/composer",
+            source=COMPOSER_CACHE_VOLUME,
+            type="volume",
+        )
+    )
+
+    # Named volume: pnpm content-addressable store (shared across all
+    # projects). Corepack's pnpm is container-local otherwise, so every
+    # container rebuild is a cold install; the npm cache doesn't help pnpm.
+    mounts.append(
+        Mount(
+            target="/root/.local/share/pnpm",
+            source=PNPM_STORE_VOLUME,
+            type="volume",
+        )
+    )
+
     # Named volume: pre-commit cache (shared across all projects).
     # Isolates the container's hook environments from the Windows host's
     # ~/.cache/pre-commit so the two installs don't clobber each other.
@@ -396,6 +443,18 @@ def build_dev_mounts(
             type="volume",
         )
     )
+
+    # Per-project named volume overlaying composer's vendor/ — the exact
+    # node_modules rationale applies verbatim. Conditional on composer.json
+    # so non-PHP projects don't grow an empty vendor/ dir on the host.
+    if (project_dir / "composer.json").is_file():
+        mounts.append(
+            Mount(
+                target=f"/root/projects/{project_name}/vendor",
+                source=vendor_volume_name(project_name),
+                type="volume",
+            )
+        )
 
     # Monorepo workspaces: overlay an isolated named volume on each matched
     # workspace's node_modules so per-app installs (npm/pnpm/yarn workspaces)

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from ai_shell.defaults import (
+    COMPOSER_CACHE_VOLUME,
     CONTAINER_PREFIX,
     DEFAULT_DEV_PORTS,
     DEV_PORT_RANGE_SIZE,
@@ -15,9 +16,11 @@ from ai_shell.defaults import (
     NODE_MODULES_VOLUME_PREFIX,
     NPM_CACHE_VOLUME,
     OLLAMA_CONTAINER,
+    PNPM_STORE_VOLUME,
     PRE_COMMIT_CACHE_PATH,
     PRE_COMMIT_CACHE_VOLUME,
     UV_CACHE_VOLUME,
+    VENDOR_VOLUME_PREFIX,
     build_dev_environment,
     build_dev_mounts,
     build_n8n_environment,
@@ -30,6 +33,7 @@ from ai_shell.defaults import (
     sanitize_project_name,
     unique_project_name,
     uv_venv_path,
+    vendor_volume_name,
 )
 
 
@@ -347,6 +351,85 @@ class TestBuildDevMounts:
         assert pc_mount is not None
         assert pc_mount.get("Source") == PRE_COMMIT_CACHE_VOLUME
         assert pc_mount.get("Type") == "volume"
+
+    def test_includes_composer_cache_volume(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        composer_mount = next(
+            (m for m in mounts if m.get("Target") == "/root/.cache/composer"), None
+        )
+        assert composer_mount is not None
+        assert composer_mount.get("Type") == "volume"
+        assert composer_mount.get("Source") == COMPOSER_CACHE_VOLUME
+
+    def test_includes_pnpm_store_volume(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        pnpm_mount = next((m for m in mounts if m.get("Target") == "/root/.local/share/pnpm"), None)
+        assert pnpm_mount is not None
+        assert pnpm_mount.get("Type") == "volume"
+        assert pnpm_mount.get("Source") == PNPM_STORE_VOLUME
+
+    def test_vendor_overlay_when_composer_json_exists(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        (project_dir / "composer.json").write_text("{}")
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        vendor_mount = next(
+            (m for m in mounts if m.get("Target") == "/root/projects/test-project/vendor"),
+            None,
+        )
+        assert vendor_mount is not None
+        assert vendor_mount.get("Type") == "volume"
+        assert vendor_mount.get("Source") == vendor_volume_name("test-project")
+        assert vendor_mount.get("Source", "").startswith(VENDOR_VOLUME_PREFIX)
+
+    def test_no_vendor_overlay_without_composer_json(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        targets = [m.get("Target") for m in mounts]
+        assert "/root/projects/test-project/vendor" not in targets
+
+    def test_vendor_volume_name_includes_worktree_suffix(self):
+        plain = vendor_volume_name("repo")
+        wt = vendor_volume_name("repo", worktree_name="feature")
+        assert plain == f"{VENDOR_VOLUME_PREFIX}repo"
+        assert wt == f"{VENDOR_VOLUME_PREFIX}repo-wt-feature"
+        assert plain != wt
+
+    def test_zapierrc_precreated_and_bind_mounted(self, tmp_path, isolate_home):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        mounts = build_dev_mounts(project_dir, "test-project")
+
+        zapierrc = isolate_home / ".zapierrc"
+        assert zapierrc.is_file()
+        assert zapierrc.read_text().strip() == "{}"
+        zapier_mount = next((m for m in mounts if m.get("Target") == "/root/.zapierrc"), None)
+        assert zapier_mount is not None
+        assert zapier_mount.get("Type") == "bind"
+        assert zapier_mount.get("ReadOnly") is not True
+
+    def test_zapierrc_existing_content_preserved(self, tmp_path, isolate_home):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        (isolate_home / ".zapierrc").write_text('{"deployKey": "secret"}')
+
+        build_dev_mounts(project_dir, "test-project")
+
+        assert (isolate_home / ".zapierrc").read_text() == '{"deployKey": "secret"}'
 
     def test_skips_missing_optional_paths(self, tmp_path):
         project_dir = tmp_path / "test-project"


### PR DESCRIPTION
Closes #130

## What

Generic PHP/Laravel + Zapier stack support for dev containers, following the existing conventions in `docker/Dockerfile`, `docker/docker-entrypoint.sh`, and `src/ai_shell/defaults.py`.

### Tools (Dockerfile)
- **PHP 8.4 CLI + extensions** via deb.sury.org: `cli pgsql sqlite3 mbstring xml curl zip intl bcmath readline` — mirrors the FrankenPHP `1-php8.4` runtime extension set (`pdo_pgsql pcntl opcache intl bcmath` plus the basics Debian packages separately; `pcntl`/`opcache` are compiled into sury's cli package)
- **Composer 2** via official installer to `/usr/local/bin/composer`
- **postgresql-client** — psql parity with the already-shipped sqlite3
- **zapier-platform-cli** npm global, refreshed in `update-tools.sh`'s npm-globals block

### Caches & volumes (defaults.py)
- `augint-shell-composer-cache` -> `/root/.cache/composer` (shared, same rationale as the uv/npm cache volumes)
- `augint-shell-pnpm-store` -> `/root/.local/share/pnpm` (shared; the npm cache volume doesn't help pnpm's content-addressable store)
- Per-project `augint-shell-vendor-<project>` overlay at `<project>/vendor` — conditional on `composer.json` existing so non-PHP projects don't grow an empty `vendor/` dir on the host
- `~/.zapierrc` rw file bind (pre-created with `{}` when missing, like the `.pi`/`.augint` dir pre-creation), so `zapier login` survives container recreation

### Entrypoint
- Best-effort `composer install --no-interaction` when `composer.json` exists, mirroring the npm block (warn-don't-fail). Also populates the vendor overlay volume on first start.

## Explicitly not included
- The issue's marked-skippable lockfile-glob item for nested package roots: the workspace overlay is already config-driven via `container.node_modules_paths` globs, so e.g. leadreaction's `zapier/` dir is coverable today with one line of `.ai-shell.yaml`.
- No global `laravel` installer, no PHP-FPM/web server, no global `sst` (per the issue's non-asks).

## Testing
- New unit tests for the composer cache / pnpm store volumes, conditional vendor overlay, vendor volume naming, and `.zapierrc` pre-creation + content preservation
- `uv run pytest` (591 passed), ruff check/format, mypy, and all pre-commit hooks green