### PR TITLE
feat(container): isolate home configs with shared named volumes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ CLI commands (cli/commands/)
 
 Dev containers mount: project dir, UV cache volume (shared), and conditionally: `~/.claude`, `~/.codex`, `~/.pi`, `~/.augint`, `~/.ssh` (ro), `~/.aws`, `~/.config/gh`, `~/.gitconfig` (ro), Docker socket (ro), plus `extra_volumes` from config.
 
+**Home-config isolation**: `container.isolate_home_paths` (config key, `AI_SHELL_ISOLATE_HOME_PATHS` env var) lists home-config basenames (e.g. `.claude`, `.codex`) to back with a shared named volume (`augint-shell-home-{name}`) instead of a host bind mount, so nothing is written into the host home dir. The volume persists across container recreations and is shared across all projects — set it in `~/.augint/.ai-shell.yaml` to apply machine-wide. Single-file configs can't be volume-backed: when named (or, for `.claude.json`, when `.claude` is isolated) their host bind is dropped and config stays container-local. Empty (default) = current bind-mount behavior. See `build_dev_mounts` / `home_config_volume_name` in `defaults.py`.
+
 ### Environment assembly
 
 Priority: `extra_env` > `./.env` > `~/.augint/.env` > `os.environ` > defaults. Layered .env loading merges `~/.augint/.env` (global shared) then `./.env` (project override). AWS IAM keys are intentionally NOT passed through (only `AWS_PROFILE` + `AWS_REGION`; relies on `~/.aws` bind mount). `IS_SANDBOX=1` is always set. Shared vars (`PRIMARY_CHAT_MODEL`, `OLLAMA_PORT`, `ANTHROPIC_API_KEY`, etc.) are passed through to container env for sibling tools. `PATH` includes `/root/.opencode/bin`.

--- a/src/ai_shell/config.py
+++ b/src/ai_shell/config.py
@@ -194,6 +194,10 @@ class AiShellConfig:
     # Glob patterns (relative to project_dir) for monorepo workspace
     # node_modules directories. Each match gets an isolated named volume.
     node_modules_paths: list[str] = field(default_factory=list)
+    # Home-config basenames (e.g. ".claude", ".codex") to back with a shared
+    # named volume instead of a host bind mount, so tool config/state never
+    # touches the host home directory. Empty = current bind-mount behavior.
+    isolate_home_paths: list[str] = field(default_factory=list)
 
     # AWS
     ai_profile: str = ""  # AWS profile for infra (sets AWS_PROFILE in container)
@@ -443,6 +447,8 @@ def _apply_config(config: AiShellConfig, path: Path) -> None:
         config.extra_ports.extend(int(p) for p in container["ports"])
     if "node_modules_paths" in container:
         config.node_modules_paths.extend(str(p) for p in container["node_modules_paths"])
+    if "isolate_home_paths" in container:
+        config.isolate_home_paths.extend(str(p) for p in container["isolate_home_paths"])
 
     # [llm] section
     llm = data.get("llm", {})
@@ -571,6 +577,11 @@ def _apply_env_vars(config: AiShellConfig) -> None:
     ports_value = os.environ.get("AI_SHELL_PORTS")
     if ports_value:
         config.extra_ports.extend(int(p.strip()) for p in ports_value.split(",") if p.strip())
+
+    # AI_SHELL_ISOLATE_HOME_PATHS is comma-separated, extends isolate_home_paths
+    isolate_value = os.environ.get("AI_SHELL_ISOLATE_HOME_PATHS")
+    if isolate_value:
+        config.isolate_home_paths.extend(p.strip() for p in isolate_value.split(",") if p.strip())
 
     # Nested voice_agent overrides (flat env vars map to nested fields)
     voice_agent_port = os.environ.get("AI_SHELL_VOICE_AGENT_PORT")

--- a/src/ai_shell/container.py
+++ b/src/ai_shell/container.py
@@ -323,6 +323,7 @@ class ContainerManager:
             self.config.project_dir,
             self.config.project_name,
             extra_node_modules_paths=self.config.node_modules_paths,
+            isolate_home_paths=set(self.config.isolate_home_paths),
         )
         environment = build_dev_environment(
             self.config.extra_env,

--- a/src/ai_shell/defaults.py
+++ b/src/ai_shell/defaults.py
@@ -32,6 +32,28 @@ SHM_SIZE = "2g"
 UV_CACHE_VOLUME = "augint-shell-uv-cache"
 GH_CONFIG_VOLUME = "augint-shell-gh-config"
 
+# Prefix for shared named volumes that back isolated home configs (e.g.
+# ~/.claude, ~/.codex). One volume per config dir, shared across all projects
+# on the host, so tool state persists in Docker instead of the host home dir.
+HOME_CONFIG_VOLUME_PREFIX = "augint-shell-home-"
+
+# Home configs that are single files rather than directories. A named volume
+# can only back a directory, so these can't be volume-isolated; when named in
+# the isolate set their host bind is dropped instead (config stays
+# container-local).
+_SINGLE_FILE_HOME_CONFIGS = frozenset({".claude.json", ".gitconfig", ".zapierrc"})
+
+
+def home_config_volume_name(config_name: str) -> str:
+    """Shared named-volume name backing an isolated home config directory.
+
+    ``.claude`` -> ``augint-shell-home-claude``. The volume is shared across
+    all projects on the host (mirroring how the host ``~/.claude`` bind is
+    shared today), so a single Claude/codex config persists in Docker instead
+    of being written into the host home directory.
+    """
+    return f"{HOME_CONFIG_VOLUME_PREFIX}{_sanitize_name(config_name.lstrip('.').lower())}"
+
 
 def uv_venv_path(repo_name: str, worktree_name: str | None = None) -> str:
     """Return the ``UV_PROJECT_ENVIRONMENT`` path for a repo.
@@ -279,6 +301,7 @@ def build_dev_mounts(
     project_dir: Path,
     project_name: str,
     extra_node_modules_paths: list[str] | None = None,
+    isolate_home_paths: set[str] | None = None,
 ) -> list[Mount]:
     """Build the full mount list matching docker-compose.yml dev service.
 
@@ -290,6 +313,14 @@ def build_dev_mounts(
     volume overlaid at ``{match}/node_modules`` inside the container, so each
     workspace in a monorepo isolates its Linux node_modules from the host
     bind mount the same way the root overlay does.
+
+    *isolate_home_paths* is a set of home-config basenames (e.g. ``.claude``,
+    ``.codex``) that should be backed by a shared named volume instead of a
+    host bind mount, so nothing is written into the host home directory. The
+    volume persists across container recreations and is shared across projects.
+    Single-file configs (``.claude.json`` etc.) can't be volume-backed; when
+    named — or, for ``.claude.json``, when ``.claude`` is isolated — their host
+    bind is dropped and the config stays container-local.
     """
     from docker.types import Mount
 
@@ -334,7 +365,32 @@ def build_dev_mounts(
         (home / ".aws", "/root/.aws", False),
     ]
 
+    isolate = isolate_home_paths or set()
     for source, target, read_only in optional_binds:
+        name = source.name
+
+        # Isolation: back the config with a shared named volume instead of a
+        # host bind, so nothing is written into the host home directory.
+        if name in isolate:
+            if name in _SINGLE_FILE_HOME_CONFIGS:
+                # A named volume can't back a single file — drop the bind so
+                # the host file is never touched (config stays container-local).
+                logger.debug("Isolating single-file home config (not persisted): %s", name)
+                continue
+            mounts.append(
+                Mount(
+                    target=target,
+                    source=home_config_volume_name(name),
+                    type="volume",
+                )
+            )
+            continue
+
+        # Keep ~/.claude.json off the host whenever ~/.claude is isolated.
+        if name == ".claude.json" and ".claude" in isolate:
+            logger.debug("Isolating .claude.json alongside isolated .claude (not persisted)")
+            continue
+
         if source.exists():
             mounts.append(
                 Mount(

--- a/src/ai_shell/templates/ai-shell.yaml
+++ b/src/ai_shell/templates/ai-shell.yaml
@@ -131,6 +131,14 @@ llm:
 # extra_env:          Additional env vars injected into the dev container.
 # extra_volumes:      Additional bind mounts ("/host:/container" or ":/path:ro").
 # ports:              Extra host ports to expose on the dev container.
+# isolate_home_paths: Home-config dirs to back with a shared named volume
+#                     instead of a host bind, so tool config/state never
+#                     touches the host home directory (e.g. ~/.claude,
+#                     ~/.codex). The volume persists across container
+#                     recreations and is shared across all projects. Put this
+#                     in ~/.augint/.ai-shell.yaml to apply it machine-wide.
+#                     Note: ~/.claude.json is a file (not volume-backed); when
+#                     .claude is isolated it is simply kept off the host.
 #
 # container:
 #   image: svange/augint-shell
@@ -142,3 +150,6 @@ llm:
 #   ports:
 #     - 9000
 #     - 9229
+#   isolate_home_paths:
+#     - .claude
+#     - .codex

--- a/src/ai_shell/templates/augint-ai-shell.example.yaml
+++ b/src/ai_shell/templates/augint-ai-shell.example.yaml
@@ -20,6 +20,13 @@
 #   extra_ports:
 #     - 8080
 #     - 9090
+#   # Back these home-config dirs with a shared named volume instead of a host
+#   # bind, so tool config/state never touches the host ~/. Persists across
+#   # container recreations, shared across all projects. ~/.claude.json (a file)
+#   # is kept off the host when .claude is isolated.
+#   isolate_home_paths:
+#     - .claude
+#     - .codex
 
 # --- LLM (Ollama model management) ------------------------------------------
 # These control which models ai-shell pulls and serves via Ollama.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -111,6 +111,22 @@ kokoro_port = 4321
         assert config.ollama_port == 12345
         assert config.kokoro_port == 4321
 
+    def test_isolate_home_paths_from_config(self, tmp_path):
+        (tmp_path / ".ai-shell.yaml").write_text(
+            "container:\n  isolate_home_paths: [.claude, .codex]\n"
+        )
+        config = load_config(project_dir=tmp_path)
+        assert config.isolate_home_paths == [".claude", ".codex"]
+
+    def test_isolate_home_paths_from_env(self, tmp_path):
+        with patch.dict("os.environ", {"AI_SHELL_ISOLATE_HOME_PATHS": ".claude, .codex"}):
+            config = load_config(project_dir=tmp_path)
+        assert config.isolate_home_paths == [".claude", ".codex"]
+
+    def test_isolate_home_paths_default_empty(self, tmp_path):
+        config = load_config(project_dir=tmp_path)
+        assert config.isolate_home_paths == []
+
     def test_env_var_overrides(self, tmp_path):
         env = {
             "AI_SHELL_IMAGE": "env/image",

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -27,6 +27,7 @@ from ai_shell.defaults import (
     build_n8n_mounts,
     dev_container_name,
     docker_tcp_fallback_host,
+    home_config_volume_name,
     node_modules_volume_name,
     project_dev_port,
     project_dev_port_map,
@@ -481,6 +482,60 @@ class TestBuildDevMounts:
         gh_mount = next((m for m in mounts if m.get("Target") == "/root/.config/gh"), None)
         assert gh_mount is not None
         assert gh_mount.get("Type") == "bind"
+
+
+class TestIsolateHomeConfigs:
+    def _mounts(self, tmp_path, isolate_home_paths):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        # Host configs exist — isolation must still bypass them.
+        (fake_home / ".claude").mkdir()
+        (fake_home / ".claude.json").write_text("{}")
+        (fake_home / ".codex").mkdir()
+        (fake_home / ".aws").mkdir()
+
+        with (
+            patch("ai_shell.defaults.Path.home", return_value=fake_home),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            return build_dev_mounts(
+                project_dir, "test-project", isolate_home_paths=isolate_home_paths
+            )
+
+    def test_volume_name_derivation(self):
+        assert home_config_volume_name(".claude") == "augint-shell-home-claude"
+        assert home_config_volume_name(".codex") == "augint-shell-home-codex"
+
+    def test_isolated_dir_uses_named_volume_not_bind(self, tmp_path):
+        mounts = self._mounts(tmp_path, {".claude", ".codex"})
+        by_target = {m.get("Target"): m for m in mounts}
+
+        for target, name in (("/root/.claude", ".claude"), ("/root/.codex", ".codex")):
+            mount = by_target[target]
+            assert mount.get("Type") == "volume"
+            assert mount.get("Source") == home_config_volume_name(name)
+
+    def test_isolating_claude_drops_claude_json_bind(self, tmp_path):
+        mounts = self._mounts(tmp_path, {".claude"})
+        targets = [m.get("Target") for m in mounts]
+        # Single file can't be volume-backed; it must not be bound to the host.
+        assert "/root/.claude.json" not in targets
+
+    def test_non_isolated_configs_still_bind(self, tmp_path):
+        mounts = self._mounts(tmp_path, {".claude"})
+        aws = next(m for m in mounts if m.get("Target") == "/root/.aws")
+        assert aws.get("Type") == "bind"
+        # .codex was not isolated and exists on host -> bind mount.
+        codex = next(m for m in mounts if m.get("Target") == "/root/.codex")
+        assert codex.get("Type") == "bind"
+
+    def test_empty_isolate_set_preserves_bind_behavior(self, tmp_path):
+        mounts = self._mounts(tmp_path, set())
+        claude = next(m for m in mounts if m.get("Target") == "/root/.claude")
+        assert claude.get("Type") == "bind"
 
 
 class TestBuildDevEnvironment:


### PR DESCRIPTION
## Summary

Adds an opt-in way to keep AI-tool home configs (e.g. `~/.claude`, `~/.codex`) **out of the host home directory** by backing them with shared Docker named volumes instead of bind mounts.

- New config key `container.isolate_home_paths` (also `AI_SHELL_ISOLATE_HOME_PATHS` env var) — a list of home-config basenames to isolate.
- Each listed dir is mounted from a shared named volume `augint-shell-home-{name}` instead of the host bind. State **persists** across container recreations and is **shared across all projects**, so dropping it in `~/.augint/.ai-shell.yaml` applies machine-wide.
- Single-file configs can't be volume-backed: when named (or, for `.claude.json`, when `.claude` is isolated) their host bind is dropped and config stays container-local.
- Empty (default) preserves the current bind-mount behavior — no change for existing setups.

### Usage
```yaml
# ~/.augint/.ai-shell.yaml
container:
  isolate_home_paths:
    - .claude
    - .codex
```

## Changes
- `defaults.py` — `home_config_volume_name()` + `build_dev_mounts(isolate_home_paths=...)`
- `config.py` — new field, YAML/TOML key, and env var parsing
- `container.py` — wires config through to `build_dev_mounts`
- Tests: `TestIsolateHomeConfigs` + 3 config-parsing tests
- Docs: `CLAUDE.md` mount-assembly section + both config templates

## Test plan
- [x] `pytest` (full suite green)
- [x] `ruff check` / `ruff format` / `mypy` clean
- [x] `pre-commit run` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)